### PR TITLE
Norm of Tensor{4, 3}

### DIFF
--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -22,6 +22,7 @@ julia> norm(A)
 """
 @inline Base.norm(v::Vec) = sqrt(dot(v, v))
 @inline Base.norm(S::SecondOrderTensor) = sqrt(dcontract(S, S))
+@inline Base.norm(S::Tensor{4, 3}) = sqrt(mapreduce(abs2, +, S))
 
 @generated function Base.norm{dim}(S::FourthOrderTensor{dim})
     idx(i,j,k,l) = compute_index(get_base(S), i, j, k, l)

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -22,6 +22,8 @@ julia> norm(A)
 """
 @inline Base.norm(v::Vec) = sqrt(dot(v, v))
 @inline Base.norm(S::SecondOrderTensor) = sqrt(dcontract(S, S))
+
+# special case for Tensor{4, 3} since it is faster than unrolling
 @inline Base.norm(S::Tensor{4, 3}) = sqrt(mapreduce(abs2, +, S))
 
 @generated function Base.norm{dim}(S::FourthOrderTensor{dim})


### PR DESCRIPTION
Adding this, since that is almost 3 times faster than unrolling. For lower dimensions unrolling is still faster:

Unrolling:
```julia
julia> for dim in (1, 2, 3)
           A = rand(Tensor{4, dim})
           @btime norm($A);
       end
  2.030 ns (0 allocations: 0 bytes)
  7.647 ns (0 allocations: 0 bytes)
  58.132 ns (0 allocations: 0 bytes)
```

`mapreduce`:
```julia
julia> for dim in (1, 2, 3)
           A = rand(Tensor{4, dim})
           @btime norm($A);
       end
  4.155 ns (0 allocations: 0 bytes)
  15.258 ns (0 allocations: 0 bytes)
  23.076 ns (0 allocations: 0 bytes)
```