### PR TITLE
[WIP] Simd operations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.5
 ForwardDiff
+SIMD
 Compat 0.19.0

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -6,7 +6,7 @@ using JLD
 include("generate_report.jl")
 
 const SUITE = BenchmarkGroup()
-const ALL_DIMENSIONS = true
+const ALL_DIMENSIONS = false
 const MIXED_SYM_NONSYM = true
 const MIXED_ELTYPES = true
 

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -6,7 +6,7 @@ using JLD
 include("generate_report.jl")
 
 const SUITE = BenchmarkGroup()
-const ALL_DIMENSIONS = false
+const ALL_DIMENSIONS = true
 const MIXED_SYM_NONSYM = true
 const MIXED_ELTYPES = true
 

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -128,8 +128,6 @@ include("transpose.jl")
 include("symmetric.jl")
 include("math_ops.jl")
 include("special_ops.jl")
-# if VERSION.minor > 5 # some weird dispatch on 0.5
-    include("simd.jl")
-# end
+include("simd.jl")
 
 end # module

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -129,6 +129,8 @@ include("transpose.jl")
 include("symmetric.jl")
 include("math_ops.jl")
 include("special_ops.jl")
-include("simd.jl")
+if VERSION.minor > 5 # some weird dispatch on 0.5
+    include("simd.jl")
+end
 
 end # module

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -4,6 +4,7 @@ module Tensors
 
 import Base.@pure
 using Compat
+import SIMD
 
 export AbstractTensor, SymmetricTensor, Tensor, Vec, FourthOrderTensor, SecondOrderTensor
 

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -128,5 +128,6 @@ include("transpose.jl")
 include("symmetric.jl")
 include("math_ops.jl")
 include("special_ops.jl")
+include("simd.jl")
 
 end # module

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -4,7 +4,6 @@ module Tensors
 
 import Base.@pure
 using Compat
-import SIMD
 
 export AbstractTensor, SymmetricTensor, Tensor, Vec, FourthOrderTensor, SecondOrderTensor
 
@@ -129,8 +128,8 @@ include("transpose.jl")
 include("symmetric.jl")
 include("math_ops.jl")
 include("special_ops.jl")
-if VERSION.minor > 5 # some weird dispatch on 0.5
+# if VERSION.minor > 5 # some weird dispatch on 0.5
     include("simd.jl")
-end
+# end
 
 end # module

--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -7,8 +7,11 @@
 @inline Base.:-{T <: AbstractTensor}(S::T) = map(-, S)
 
 # Binary
-@inline Base.:+(S1::AbstractTensor, S2::AbstractTensor) = map(+, S1, S2)
-@inline Base.:-(S1::AbstractTensor, S2::AbstractTensor) = map(-, S1, S2)
+@inline Base.:+{T<:AbstractTensor}(S1::T, S2::T) = map(+, S1, S2)
+@inline Base.:+(S1::AbstractTensor, S2::AbstractTensor) = +(promote(S1, S2)...)
+@inline Base.:-{T<:AbstractTensor}(S1::T, S2::T) = map(-, S1, S2)
+@inline Base.:-(S1::AbstractTensor, S2::AbstractTensor) = -(promote(S1, S2)...)
+
 @inline Base.:*(S::AbstractTensor, n::Number) = map(x->(x*n), S)
 @inline Base.:*(n::Number, S::AbstractTensor) = map(x->(n*x), S)
 @inline Base.:/(S::AbstractTensor, n::Number) = map(x->(x/n), S)
@@ -24,7 +27,6 @@
     end
 end
 
-@inline Base.map{order, dim, T1, T2}(f, S1::AbstractTensor{order, dim, T1}, S2::AbstractTensor{order, dim, T2}) = ((SS1, SS2) = promote(S1, S2); map(f, SS1, SS2))
 @generated function Base.map{T <: AllTensors}(f, S1::T, S2::T)
     TensorType = get_base(S1)
     N = n_components(TensorType)

--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -7,9 +7,11 @@
 @inline Base.:-{T <: AbstractTensor}(S::T) = map(-, S)
 
 # Binary
-@inline Base.:+{T<:AbstractTensor}(S1::T, S2::T) = map(+, S1, S2)
+@inline Base.:+{order, dim, T}(S1::Tensor{order, dim, T}, S2::Tensor{order, dim, T}) = map(+, S1, S2)
+@inline Base.:+{order, dim, T}(S1::SymmetricTensor{order, dim, T}, S2::SymmetricTensor{order, dim, T}) = map(+, S1, S2)
 @inline Base.:+(S1::AbstractTensor, S2::AbstractTensor) = +(promote(S1, S2)...)
-@inline Base.:-{T<:AbstractTensor}(S1::T, S2::T) = map(-, S1, S2)
+@inline Base.:-{order, dim, T}(S1::Tensor{order, dim, T}, S2::Tensor{order, dim, T}) = map(-, S1, S2)
+@inline Base.:-{order, dim, T}(S1::SymmetricTensor{order, dim, T}, S2::SymmetricTensor{order, dim, T}) = map(-, S1, S2)
 @inline Base.:-(S1::AbstractTensor, S2::AbstractTensor) = -(promote(S1, S2)...)
 
 @inline Base.:*(S::AbstractTensor, n::Number) = map(x->(x*n), S)

--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -7,11 +7,9 @@
 @inline Base.:-{T <: AbstractTensor}(S::T) = map(-, S)
 
 # Binary
-@inline Base.:+{order, dim, T}(S1::Tensor{order, dim, T}, S2::Tensor{order, dim, T}) = map(+, S1, S2)
-@inline Base.:+{order, dim, T}(S1::SymmetricTensor{order, dim, T}, S2::SymmetricTensor{order, dim, T}) = map(+, S1, S2)
+@inline Base.:+{T <: AbstractTensor}(S1::T, S2::T) = map(+, S1, S2)
 @inline Base.:+(S1::AbstractTensor, S2::AbstractTensor) = +(promote(S1, S2)...)
-@inline Base.:-{order, dim, T}(S1::Tensor{order, dim, T}, S2::Tensor{order, dim, T}) = map(-, S1, S2)
-@inline Base.:-{order, dim, T}(S1::SymmetricTensor{order, dim, T}, S2::SymmetricTensor{order, dim, T}) = map(-, S1, S2)
+@inline Base.:-{T <: AbstractTensor}(S1::T, S2::T) = map(-, S1, S2)
 @inline Base.:-(S1::AbstractTensor, S2::AbstractTensor) = -(promote(S1, S2)...)
 
 @inline Base.:*(S::AbstractTensor, n::Number) = map(x->(x*n), S)

--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -7,9 +7,11 @@
 @inline Base.:-{T <: AbstractTensor}(S::T) = map(-, S)
 
 # Binary
-@inline Base.:+{T <: AbstractTensor}(S1::T, S2::T) = map(+, S1, S2)
+@inline Base.:+{order, dim, T}(S1::Tensor{order, dim, T}, S2::Tensor{order, dim, T}) = map(+, S1, S2)
+@inline Base.:+{order, dim, T}(S1::SymmetricTensor{order, dim, T}, S2::SymmetricTensor{order, dim, T}) = map(+, S1, S2)
 @inline Base.:+(S1::AbstractTensor, S2::AbstractTensor) = +(promote(S1, S2)...)
-@inline Base.:-{T <: AbstractTensor}(S1::T, S2::T) = map(-, S1, S2)
+@inline Base.:-{order, dim, T}(S1::Tensor{order, dim, T}, S2::Tensor{order, dim, T}) = map(-, S1, S2)
+@inline Base.:-{order, dim, T}(S1::SymmetricTensor{order, dim, T}, S2::SymmetricTensor{order, dim, T}) = map(-, S1, S2)
 @inline Base.:-(S1::AbstractTensor, S2::AbstractTensor) = -(promote(S1, S2)...)
 
 @inline Base.:*(S::AbstractTensor, n::Number) = map(x->(x*n), S)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -24,7 +24,7 @@ end
         if length(data) != $N
             throw(ArgumentError("wrong number of elements, expected $($N), got $(length(data))"))
         end
-        println("BAD DISPATCH")
+        # println("BAD DISPATCH")
         Tensor{order, dim}($exp)
     end
 end
@@ -36,7 +36,7 @@ end
     M = n_components(SymmetricTensor{order,dim})
     expM = Expr(:tuple, [:(data[$i]) for i in 1:M]...)
     return quote
-        println("BAD DISPATCH")
+        # println("BAD DISPATCH")
         L = length(data)
         if L != $N && L != $M
             throw(ArgumentError("wrong number of vector elements, expected $($N) or $($M), got $L"))

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -24,6 +24,7 @@ end
         if length(data) != $N
             throw(ArgumentError("wrong number of elements, expected $($N), got $(length(data))"))
         end
+        println("BAD DISPATCH")
         Tensor{order, dim}($exp)
     end
 end
@@ -35,6 +36,7 @@ end
     M = n_components(SymmetricTensor{order,dim})
     expM = Expr(:tuple, [:(data[$i]) for i in 1:M]...)
     return quote
+        println("BAD DISPATCH")
         L = length(data)
         if L != $N && L != $M
             throw(ArgumentError("wrong number of vector elements, expected $($N) or $($M), got $L"))

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -17,7 +17,7 @@ julia> A = rand(Tensor{2,3})
  0.566237  0.854147  0.246837
 
 julia> norm(A)
-1.7377443667834922
+1.7377443667834924
 ```
 """
 @inline Base.norm(v::Vec) = sqrt(dot(v, v))

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -148,7 +148,7 @@ end
 # (2): * and / between tensor and number #
 ##########################################
 # note it is allowed with different eltypes, since it is promoted in SIMD.jl
-@generated function Base.:*{T1 <: SIMDTypes, T2 <: SIMDTypes}(n::T1, S::AllSIMDTensors{T2})
+@generated function Base.:*{T <: SIMDTypes}(n::T, S::AllSIMDTensors{T})
     TensorType = get_base(S)
     return quote
         $(Expr(:meta, :inline))
@@ -159,7 +159,7 @@ end
         end
     end
 end
-@generated function Base.:*{T1 <: SIMDTypes, T2 <: SIMDTypes}(n::T1, S::Tensor{4, 3, T2})
+@generated function Base.:*{T <: SIMDTypes}(n::T, S::Tensor{4, 3, T})
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
@@ -169,7 +169,7 @@ end
         end
     end
 end
-@generated function Base.:*{T1 <: SIMDTypes, T2 <: SIMDTypes}(S::AllSIMDTensors{T1}, n::T2)
+@generated function Base.:*{T <: SIMDTypes}(S::AllSIMDTensors{T}, n::T)
     TensorType = get_base(S)
     return quote
         $(Expr(:meta, :inline))
@@ -180,7 +180,7 @@ end
         end
     end
 end
-@generated function Base.:*{T1 <: SIMDTypes, T2 <: SIMDTypes}(S::Tensor{4, 3, T1}, n::T2)
+@generated function Base.:*{T <: SIMDTypes}(S::Tensor{4, 3, T}, n::T)
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
@@ -190,7 +190,7 @@ end
         end
     end
 end
-@generated function Base.:/{T1 <: SIMDTypes, T2 <: SIMDTypes}(S::AllSIMDTensors{T1}, n::T2)
+@generated function Base.:/{T <: SIMDTypes}(S::AllSIMDTensors{T}, n::T)
     TensorType = get_base(S)
     return quote
         $(Expr(:meta, :inline))
@@ -201,7 +201,7 @@ end
         end
     end
 end
-@generated function Base.:/{T1 <: SIMDTypes, T2 <: SIMDTypes}(S::Tensor{4, 3, T1}, n::T2)
+@generated function Base.:/{T <: SIMDTypes}(S::Tensor{4, 3, T}, n::T)
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -185,7 +185,7 @@ end
         $(Expr(:meta, :inline))
         @inbounds begin
             D = get_data(S); SV80 = tosimd(D, Val{1}, Val{80})
-            r = SV80 * n; r81 = D * n
+            r = SV80 * n; r81 = D[81] * n
             return Tensor{4, 3}($(Expr(:tuple, [:(r[$i]) for i in 1:80]..., :(r81))))
         end
     end
@@ -206,7 +206,7 @@ end
         $(Expr(:meta, :inline))
         @inbounds begin
             D = get_data(S); SV80 = tosimd(D, Val{1}, Val{80})
-            r = SV80 / n; r81 = D / n
+            r = SV80 / n; r81 = D[81] / n
             return Tensor{4, 3}($(Expr(:tuple, [:(r[$i]) for i in 1:80]..., :(r81))))
         end
     end

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -24,11 +24,11 @@ import SIMD
 
 const SIMDTypes = Union{Float16, Float32, Float64}
 
-@compat const AllSIMDTensors{T <: SIMDTypes} = Union{Vec{1, T}, Vec{2, T}, Vec{3, T},
-                                                     Tensor{2, 1, T}, Tensor{2, 2, T}, Tensor{2, 3, T},
-                                                     Tensor{4, 1, T}, Tensor{4, 2, T}, Tensor{4, 3, T},
-                                                     SymmetricTensor{2, 1, T}, SymmetricTensor{2, 2, T}, SymmetricTensor{2, 3, T},
-                                                     SymmetricTensor{4, 1, T}, SymmetricTensor{4, 2, T}, SymmetricTensor{4, 3, T}}
+@compat const AllSIMDTensors{T <: SIMDTypes} = Union{Tensor{1, 1, T, 1}, Tensor{1, 2, T, 2}, Tensor{1, 3, T, 3},
+                                                     Tensor{2, 1, T, 1}, Tensor{2, 2, T, 4}, Tensor{2, 3, T, 9},
+                                                     Tensor{4, 1, T, 1}, Tensor{4, 2, T, 16}, #=Tensor{4, 3, T, 81},=#
+                                                     SymmetricTensor{2, 1, T, 1}, SymmetricTensor{2, 2, T, 3}, SymmetricTensor{2, 3, T, 6},
+                                                     SymmetricTensor{4, 1, T, 1}, SymmetricTensor{4, 2, T, 9}, SymmetricTensor{4, 3, T, 36}}
 
 # SIMD sizes accepted by LLVM between 1 and 100
 const SIMD_CHUNKS = (1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 16, 17, 18, 20, 24, 32, 33, 34, 36, 40, 48, 64, 65, 66, 68, 72, 80, 96)

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -215,15 +215,6 @@ end
 # (3): dot #
 ############
 # 2-1
-@inline function Base.dot{T <: SIMDTypes, N}(S1::Tensor{2, 1, T, N}, S2::Vec{1, T})
-    @inbounds begin
-        D1 = get_data(S1)
-        D2 = get_data(S2)
-        D11 = SVec{1, T}((D1[1],))
-        r = D11 * D2[1]
-        return Tensor{1, 1}(r)
-    end
-end
 @inline function Base.dot{T <: SIMDTypes, N}(S1::Tensor{2, 2, T, N}, S2::Vec{2, T})
     @inbounds begin
         D1 = get_data(S1)
@@ -249,15 +240,6 @@ end
 end
 
 # 2-2
-@inline function Base.dot{T <: SIMDTypes}(S1::Tensor{2, 1, T}, S2::Tensor{2, 1, T})
-    @inbounds begin
-        D1 = get_data(S1)
-        D2 = get_data(S2)
-        D11 = SVec{1, T}((D1[1], ))
-        r1 = D11 * D2[1]
-        return Tensor{2, 1}((r1,))
-    end
-end
 @inline function Base.dot{T <: SIMDTypes}(S1::Tensor{2, 2, T}, S2::Tensor{2, 2, T})
     @inbounds begin
         D1 = get_data(S1)
@@ -310,15 +292,6 @@ end
 end
 
 # 4-2
-@inline function Tensors.dcontract{T <: SIMDTypes}(S1::Tensor{4, 1, T}, S2::Tensor{2, 1, T})
-    @inbounds begin
-        D1 = get_data(S1)
-        D2 = get_data(S2)
-        D11 = SVec{1, T}((D1[1], ))
-        r  = D11 * D2[1]
-        return Tensor{2, 1}(r)
-    end
-end
 @inline function Tensors.dcontract{T <: SIMDTypes}(S1::Tensor{4, 2, T}, S2::Tensor{2, 2, T})
     @inbounds begin
         D1 = get_data(S1)
@@ -357,15 +330,6 @@ end
 end
 
 # 4-4
-@inline function Tensors.dcontract{T <: SIMDTypes}(S1::Tensor{4, 1, T}, S2::Tensor{4, 1, T})
-    @inbounds begin
-        D1 = get_data(S1)
-        D2 = get_data(S2)
-        D11 = SVec{1, T}((D1[1], ))
-        r1  = D11 * D2[1]
-        return Tensor{4, 1}((r1, ))
-    end
-end
 @inline function Tensors.dcontract{T <: SIMDTypes}(S1::Tensor{4, 2, T}, S2::Tensor{4, 2, T})
     @inbounds begin
         D1 = get_data(S1)
@@ -459,15 +423,6 @@ end
 ###############
 # (5): otimes #
 ###############
-@inline function Tensors.otimes{T <: SIMDTypes}(S1::Vec{1, T}, S2::Vec{1, T})
-    @inbounds begin
-        D1 = get_data(S1)
-        D2 = get_data(S2)
-        D11 = SVec{1, T}((D1[1], ))
-        r1 = D11 * D2[1]
-        return Tensor{2, 1}((r1, ))
-    end
-end
 @inline function Tensors.otimes{T <: SIMDTypes}(S1::Vec{2, T}, S2::Vec{2, T})
     @inbounds begin
         D1 = get_data(S1)
@@ -485,15 +440,6 @@ end
         D11 = SVec{3, T}((D1[1], D1[2], D1[3]))
         r1 = D11 * D2[1]; r2 = D11 * D2[2]; r3 = D11 * D2[3]
         return Tensor{2, 3}((r1, r2, r3))
-    end
-end
-@inline function Tensors.otimes{T <: SIMDTypes}(S1::Tensor{2, 1, T}, S2::Tensor{2, 1, T})
-    @inbounds begin
-        D1 = get_data(S1)
-        D2 = get_data(S2)
-        D11 = SVec{1, T}(D1)
-        r1 = D11 * D2[1]
-        return Tensor{4, 1}((r1[1], ))
     end
 end
 @inline function Tensors.otimes{T <: SIMDTypes}(S1::Tensor{2, 2, T}, S2::Tensor{2, 2, T})

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -1,6 +1,6 @@
 #=
-This module contains explicit SIMD instructions for tensors.
-Many of the methods defined outside this module will use SIMD-instructions
+This file contains explicit SIMD instructions for tensors.
+Many of the methods defined outside this file will use SIMD-instructions
 if julia is ran with -O3. Even if -O3 is enabled, the compiler is sometimes
 thrown off guard, and therefore, explicit SIMD routines are
 defined. This will enable SIMD-instructions even if julia is ran with
@@ -10,7 +10,7 @@ The functions here are only defined for tensors of the same
 element type. Otherwise it does work. Promotion should take
 care of this before the tensors enter the functions here.
 
-The module is organized as follows:
+The file is organized as follows:
 (1): + and - between tensors
 (2): * and / between tensor and number
 (3): dot
@@ -18,18 +18,17 @@ The module is organized as follows:
 (5): otimes
 (6): norm
 =#
-module ExplicitSIMD
-
-using Tensors
-using Tensors: AllTensors, get_data, n_components, get_base
-using Compat
 
 import SIMD
 @compat const SVec{N, T} = SIMD.Vec{N, T}
 
 const SIMDTypes = Union{Float16, Float32, Float64}
 
-@compat const AllSIMDTensors{T <: SIMDTypes, dim} = AllTensors{dim, T} # T more useful so swapping
+@compat const AllSIMDTensors{T <: SIMDTypes} = Union{Vec{1, T}, Vec{2, T}, Vec{3, T},
+                                                     Tensor{2, 1, T}, Tensor{2, 2, T}, Tensor{2, 3, T},
+                                                     Tensor{4, 1, T}, Tensor{4, 2, T}, Tensor{4, 3, T},
+                                                     SymmetricTensor{2, 1, T}, SymmetricTensor{2, 2, T}, SymmetricTensor{2, 3, T},
+                                                     SymmetricTensor{4, 1, T}, SymmetricTensor{4, 2, T}, SymmetricTensor{4, 3, T}}
 
 # SIMD sizes accepted by LLVM between 1 and 100
 const SIMD_CHUNKS = (1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 16, 17, 18, 20, 24, 32, 33, 34, 36, 40, 48, 64, 65, 66, 68, 72, 80, 96)
@@ -419,5 +418,3 @@ end
         return sqrt(r)
     end
 end
-
-end # module

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -27,10 +27,7 @@ using Compat
 import SIMD
 @compat const SVec{N, T} = SIMD.Vec{N, T}
 
-const SIMDTypes = Union{Bool,
-                        Int8, Int16, Int32, Int64, Int128,
-                        UInt8, UInt16, UInt32, UInt64, UInt128,
-                        Float16, Float32, Float64}
+const SIMDTypes = Union{Float16, Float32, Float64}
 
 @compat const AllSIMDTensors{T <: SIMDTypes, dim} = AllTensors{dim, T} # T more useful so swapping
 

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -6,6 +6,10 @@ thrown off guard, and therefore, explicit SIMD routines are
 defined. This will enable SIMD-instructions even if julia is ran with
 the default -O2.
 
+The functions here are only defined for tensors of the same
+element type. Otherwise it does work. Promotion should take
+care of this before the tensors enter the functions here.
+
 The module is organized as follows:
 (1): + and - between tensors
 (2): * and / between tensor and number
@@ -138,6 +142,7 @@ end
 ##########################################
 # (2): * and / between tensor and number #
 ##########################################
+# note it is allowed with different eltypes, since it is promoted in SIMD.jl
 @generated function Base.:*{T1 <: SIMDTypes, T2 <: SIMDTypes}(n::T1, S::AllSIMDTensors{T2})
     TensorType = get_base(S)
     N = n_components(TensorType)

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -216,13 +216,12 @@ end
 # (3): dot #
 ############
 # 2-1
-
 @inline function Base.dot{T <: SIMDTypes, N}(S1::Tensor{2, 2, T, N}, S2::Vec{2, T})
     @inbounds begin
         D1 = get_data(S1); D2 = get_data(S2)
         SV11 = tosimd(D1, Val{1}, Val{2})
         SV12 = tosimd(D1, Val{3}, Val{4})
-        r = fma(SV12, D2[2], SV11 * D2[1])
+        r = muladd(SV12, D2[2], SV11 * D2[1])
         return Tensor{1, 2}(r)
     end
 end
@@ -232,7 +231,7 @@ end
         SV11 = tosimd(D1, Val{1}, Val{3})
         SV12 = tosimd(D1, Val{4}, Val{6})
         SV13 = tosimd(D1, Val{7}, Val{9})
-        r = fma(SV13, D2[3], fma(SV12, D2[2], SV11 * D2[1]))
+        r = muladd(SV13, D2[3], muladd(SV12, D2[2], SV11 * D2[1]))
         return Tensor{1, 3}(r)
     end
 end
@@ -243,8 +242,8 @@ end
         D1 = get_data(S1); D2 = get_data(S2)
         SV11 = tosimd(D1, Val{1}, Val{2})
         SV12 = tosimd(D1, Val{3}, Val{4})
-        r1 = fma(SV12, D2[2], SV11 * D2[1])
-        r2 = fma(SV12, D2[4], SV11 * D2[3])
+        r1 = muladd(SV12, D2[2], SV11 * D2[1])
+        r2 = muladd(SV12, D2[4], SV11 * D2[3])
         return Tensor{2, 2}((r1, r2))
     end
 end
@@ -254,9 +253,9 @@ end
         SV11 = tosimd(D1, Val{1}, Val{3})
         SV12 = tosimd(D1, Val{4}, Val{6})
         SV13 = tosimd(D1, Val{7}, Val{9})
-        r1 = fma(SV13, D2[3], fma(SV12, D2[2], SV11 * D2[1]))
-        r2 = fma(SV13, D2[6], fma(SV12, D2[5], SV11 * D2[4]))
-        r3 = fma(SV13, D2[9], fma(SV12, D2[8], SV11 * D2[7]))
+        r1 = muladd(SV13, D2[3], muladd(SV12, D2[2], SV11 * D2[1]))
+        r2 = muladd(SV13, D2[6], muladd(SV12, D2[5], SV11 * D2[4]))
+        r3 = muladd(SV13, D2[9], muladd(SV12, D2[8], SV11 * D2[7]))
         return Tensor{2, 3}((r1, r2, r3))
     end
 end
@@ -292,7 +291,7 @@ end
         SV12 = tosimd(D1, Val{5}, Val{8})
         SV13 = tosimd(D1, Val{9}, Val{12})
         SV14 = tosimd(D1, Val{13}, Val{16})
-        r = fma(SV14, D2[4], fma(SV13, D2[3], fma(SV12, D2[2], SV11 * D2[1])))
+        r = muladd(SV14, D2[4], muladd(SV13, D2[3], muladd(SV12, D2[2], SV11 * D2[1])))
         return Tensor{2, 2}(r)
     end
 end
@@ -308,7 +307,7 @@ end
         SV17 = tosimd(D1, Val{55}, Val{63})
         SV18 = tosimd(D1, Val{64}, Val{72})
         SV19 = tosimd(D1, Val{73}, Val{81})
-        r = fma(SV19, D2[9], fma(SV18, D2[8], fma(SV17, D2[7], fma(SV16, D2[6], fma(SV15, D2[5], fma(SV14, D2[4], fma(SV13, D2[3], fma(SV12, D2[2], SV11 * D2[1]))))))))
+        r = muladd(SV19, D2[9], muladd(SV18, D2[8], muladd(SV17, D2[7], muladd(SV16, D2[6], muladd(SV15, D2[5], muladd(SV14, D2[4], muladd(SV13, D2[3], muladd(SV12, D2[2], SV11 * D2[1]))))))))
         return return Tensor{2, 3}(r)
     end
 end
@@ -321,10 +320,10 @@ end
         SV12 = tosimd(D1, Val{5},  Val{8})
         SV13 = tosimd(D1, Val{9},  Val{12})
         SV14 = tosimd(D1, Val{13}, Val{16})
-        r1 = fma(SV14, D2[4],  fma(SV13, D2[3],  fma(SV12, D2[2],  SV11 * D2[1])))
-        r2 = fma(SV14, D2[8],  fma(SV13, D2[7],  fma(SV12, D2[6],  SV11 * D2[5])))
-        r3 = fma(SV14, D2[12], fma(SV13, D2[11], fma(SV12, D2[10], SV11 * D2[9])))
-        r4 = fma(SV14, D2[16], fma(SV13, D2[15], fma(SV12, D2[14], SV11 * D2[13])))
+        r1 = muladd(SV14, D2[4],  muladd(SV13, D2[3],  muladd(SV12, D2[2],  SV11 * D2[1])))
+        r2 = muladd(SV14, D2[8],  muladd(SV13, D2[7],  muladd(SV12, D2[6],  SV11 * D2[5])))
+        r3 = muladd(SV14, D2[12], muladd(SV13, D2[11], muladd(SV12, D2[10], SV11 * D2[9])))
+        r4 = muladd(SV14, D2[16], muladd(SV13, D2[15], muladd(SV12, D2[14], SV11 * D2[13])))
         return Tensor{4, 2}((r1, r2, r3, r4))
     end
 end
@@ -340,15 +339,15 @@ end
         SV17 = tosimd(D1, Val{55}, Val{63})
         SV18 = tosimd(D1, Val{64}, Val{72})
         SV19 = tosimd(D1, Val{73}, Val{81})
-        r1 = fma(SV19, D2[9],  fma(SV18, D2[8],  fma(SV17, D2[7],  fma(SV16, D2[6],  fma(SV15, D2[5],  fma(SV14, D2[4],  fma(SV13, D2[3],  fma(SV12, D2[2],  SV11 * D2[1] ))))))))
-        r2 = fma(SV19, D2[18], fma(SV18, D2[17], fma(SV17, D2[16], fma(SV16, D2[15], fma(SV15, D2[14], fma(SV14, D2[13], fma(SV13, D2[12], fma(SV12, D2[11], SV11 * D2[10]))))))))
-        r3 = fma(SV19, D2[27], fma(SV18, D2[26], fma(SV17, D2[25], fma(SV16, D2[24], fma(SV15, D2[23], fma(SV14, D2[22], fma(SV13, D2[21], fma(SV12, D2[20], SV11 * D2[19]))))))))
-        r4 = fma(SV19, D2[36], fma(SV18, D2[35], fma(SV17, D2[34], fma(SV16, D2[33], fma(SV15, D2[32], fma(SV14, D2[31], fma(SV13, D2[30], fma(SV12, D2[29], SV11 * D2[28]))))))))
-        r5 = fma(SV19, D2[45], fma(SV18, D2[44], fma(SV17, D2[43], fma(SV16, D2[42], fma(SV15, D2[41], fma(SV14, D2[40], fma(SV13, D2[39], fma(SV12, D2[38], SV11 * D2[37]))))))))
-        r6 = fma(SV19, D2[54], fma(SV18, D2[53], fma(SV17, D2[52], fma(SV16, D2[51], fma(SV15, D2[50], fma(SV14, D2[49], fma(SV13, D2[48], fma(SV12, D2[47], SV11 * D2[46]))))))))
-        r7 = fma(SV19, D2[63], fma(SV18, D2[62], fma(SV17, D2[61], fma(SV16, D2[60], fma(SV15, D2[59], fma(SV14, D2[58], fma(SV13, D2[57], fma(SV12, D2[56], SV11 * D2[55]))))))))
-        r8 = fma(SV19, D2[72], fma(SV18, D2[71], fma(SV17, D2[70], fma(SV16, D2[69], fma(SV15, D2[68], fma(SV14, D2[67], fma(SV13, D2[66], fma(SV12, D2[65], SV11 * D2[64]))))))))
-        r9 = fma(SV19, D2[81], fma(SV18, D2[80], fma(SV17, D2[79], fma(SV16, D2[78], fma(SV15, D2[77], fma(SV14, D2[76], fma(SV13, D2[75], fma(SV12, D2[74], SV11 * D2[73]))))))))
+        r1 = muladd(SV19, D2[9],  muladd(SV18, D2[8],  muladd(SV17, D2[7],  muladd(SV16, D2[6],  muladd(SV15, D2[5],  muladd(SV14, D2[4],  muladd(SV13, D2[3],  muladd(SV12, D2[2],  SV11 * D2[1] ))))))))
+        r2 = muladd(SV19, D2[18], muladd(SV18, D2[17], muladd(SV17, D2[16], muladd(SV16, D2[15], muladd(SV15, D2[14], muladd(SV14, D2[13], muladd(SV13, D2[12], muladd(SV12, D2[11], SV11 * D2[10]))))))))
+        r3 = muladd(SV19, D2[27], muladd(SV18, D2[26], muladd(SV17, D2[25], muladd(SV16, D2[24], muladd(SV15, D2[23], muladd(SV14, D2[22], muladd(SV13, D2[21], muladd(SV12, D2[20], SV11 * D2[19]))))))))
+        r4 = muladd(SV19, D2[36], muladd(SV18, D2[35], muladd(SV17, D2[34], muladd(SV16, D2[33], muladd(SV15, D2[32], muladd(SV14, D2[31], muladd(SV13, D2[30], muladd(SV12, D2[29], SV11 * D2[28]))))))))
+        r5 = muladd(SV19, D2[45], muladd(SV18, D2[44], muladd(SV17, D2[43], muladd(SV16, D2[42], muladd(SV15, D2[41], muladd(SV14, D2[40], muladd(SV13, D2[39], muladd(SV12, D2[38], SV11 * D2[37]))))))))
+        r6 = muladd(SV19, D2[54], muladd(SV18, D2[53], muladd(SV17, D2[52], muladd(SV16, D2[51], muladd(SV15, D2[50], muladd(SV14, D2[49], muladd(SV13, D2[48], muladd(SV12, D2[47], SV11 * D2[46]))))))))
+        r7 = muladd(SV19, D2[63], muladd(SV18, D2[62], muladd(SV17, D2[61], muladd(SV16, D2[60], muladd(SV15, D2[59], muladd(SV14, D2[58], muladd(SV13, D2[57], muladd(SV12, D2[56], SV11 * D2[55]))))))))
+        r8 = muladd(SV19, D2[72], muladd(SV18, D2[71], muladd(SV17, D2[70], muladd(SV16, D2[69], muladd(SV15, D2[68], muladd(SV14, D2[67], muladd(SV13, D2[66], muladd(SV12, D2[65], SV11 * D2[64]))))))))
+        r9 = muladd(SV19, D2[81], muladd(SV18, D2[80], muladd(SV17, D2[79], muladd(SV16, D2[78], muladd(SV15, D2[77], muladd(SV14, D2[76], muladd(SV13, D2[75], muladd(SV12, D2[74], SV11 * D2[73]))))))))
         return Tensor{4, 3}((r1, r2, r3, r4, r5, r6, r7, r8, r9))
     end
 end

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -1,0 +1,576 @@
+# this files contains some performance related stuff
+module ST # SIMDTensors
+
+using Tensors
+using Tensors: get_data
+using Compat
+
+import SIMD
+@compat const SVec{N, T} = SIMD.Vec{N, T}
+
+const SIMDTypes = Union{Bool,
+                        Int8, Int16, Int32, Int32, Int128,
+                        UInt8, UInt16, UInt32, UInt32, UInt128,
+                        Float16, Float32, Float64}
+
+# SIMD sizes accepted by LLVM between 1 and 100
+const SIMD_CHUNKS = (1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 16, 17, 18, 20, 24, 32, 33, 34, 36, 40, 48, 64, 65, 66, 68, 72, 80, 96)
+
+# factors for the symmetric tensors
+function symmetric_factors(order, dim, T)
+    if order == 2
+        dim == 1 && return SVec{1, T}((T(1),))
+        dim == 2 && return SVec{3, T}((T(1),T(2),T(1)))
+        dim == 3 && return SVec{6, T}((T(1),T(2),T(2),T(1),T(2),T(1)))
+    elseif order == 4
+        dim == 1 && return SVec{1, T}((T(1),))
+        dim == 2 && return SVec{9, T}((T(1),T(2),T(1),T(2),T(4),T(2),T(1),T(2),T(1)))
+        dim == 3 && return SVec{36,T}((T(1),T(2),T(2),T(1),T(2),T(1),T(2),T(4),T(4),T(2),T(4),T(2),
+                                       T(2),T(4),T(4),T(2),T(4),T(2),T(1),T(2),T(2),T(1),T(2),T(1),
+                                       T(2),T(4),T(4),T(2),T(4),T(2),T(1),T(2),T(2),T(1),T(2),T(1)))
+    end
+end
+
+# norm
+@inline function norm{dim, T <: SIMDTypes}(S::Union{Vec{dim, T}, Tensor{2, dim, T}, Tensor{4, dim, T}})
+    v = zero(T)
+    @inbounds @simd for i in 1:length(S)
+        v += S[i] * S[i]
+    end
+    return sqrt(v)
+end
+
+@inline function norm{T <: SIMDTypes}(S::Tensor{1, 1, T})
+    D = SVec{1, T}(get_data(S))
+    DD = D * D
+    sDD = sum(DD)
+    return sqrt(sDD)
+end
+
+@inline function norm{T <: SIMDTypes}(S::Tensor{1, 2, T})
+    D = SVec{2, T}(get_data(S))
+    DD = D * D
+    sDD = sum(DD)
+    return sqrt(sDD)
+end
+
+@inline function norm{T <: SIMDTypes}(S::Tensor{1, 3, T})
+    D = SVec{3, T}(get_data(S))
+    DD = D * D
+    sDD = sum(DD)
+    return sqrt(sDD)
+end
+
+@inline function norm{T <: SIMDTypes}(S::Tensor{2, 1, T})
+    D = SVec{1, T}(get_data(S))
+    DD = D * D
+    sDD = sum(DD)
+    return sqrt(sDD)
+end
+
+@inline function norm{T <: SIMDTypes}(S::Tensor{2, 2, T})
+    D = SVec{4, T}(get_data(S))
+    DD = D * D
+    sDD = sum(DD)
+    return sqrt(sDD)
+end
+
+@inline function norm{T <: SIMDTypes}(S::Tensor{2, 3, T})
+    D = SVec{9, T}(get_data(S))
+    DD = D * D
+    sDD = sum(DD)
+    return sqrt(sDD)
+end
+
+@inline function norm{T <: SIMDTypes}(S::Tensor{4, 1, T})
+    D = SVec{1, T}(get_data(S))
+    DD = D * D
+    sDD = sum(DD)
+    return sqrt(sDD)
+end
+
+@inline function norm{T <: SIMDTypes}(S::Tensor{4, 2, T})
+    D = SVec{16, T}(get_data(S))
+    DD = D * D
+    sDD = sum(DD)
+    return sqrt(sDD)
+end
+
+@inline function norm{T <: SIMDTypes}(S::Tensor{4, 3, T})
+    @inbounds begin
+        D = get_data(S)
+        D80 = SVec{80, T}((D[1],  D[2],  D[3],  D[4],  D[5],  D[6],  D[7],  D[8],  D[9],
+                           D[10], D[11], D[12], D[13], D[14], D[15], D[16], D[17], D[18],
+                           D[19], D[20], D[21], D[22], D[23], D[24], D[25], D[26], D[27],
+                           D[28], D[29], D[30], D[31], D[32], D[33], D[34], D[35], D[36],
+                           D[37], D[38], D[39], D[40], D[41], D[42], D[43], D[44], D[45],
+                           D[46], D[47], D[48], D[49], D[50], D[51], D[52], D[53], D[54],
+                           D[55], D[56], D[57], D[58], D[59], D[60], D[61], D[62], D[63],
+                           D[64], D[65], D[66], D[67], D[68], D[69], D[70], D[71], D[72],
+                           D[73], D[74], D[75], D[76], D[77], D[78], D[79], D[80]))
+        D80D80 = D80 * D80
+        v = sum(D80D80)
+        v += D[81] * D[81]
+        return sqrt(v)
+    end
+end
+
+# rely on fast dcontract
+@inline norm{dim, T <: SIMDTypes}(S::SymmetricTensor{2, dim, T}) = sqrt(dcontract(S, S))
+
+@inline function norm{T <: SIMDTypes}(S::SymmetricTensor{4, 1, T})
+    F = SVec{1, T}((T(1), ))
+    D = SVec{1, T}(get_data(S))
+    DD = D*D; FDD = F * DD; sFDD = sum(FDD)
+    return sqrt(sFDD)
+end
+@inline function norm{T <: SIMDTypes}(S::SymmetricTensor{4, 2, T})
+    F = SVec{9, T}((T(1), T(2), T(1), T(2), T(4), T(2), T(1), T(2), T(1)))
+    D = SVec{9, T}(get_data(S))
+    DD = D * D; FDD = F * DD; sFDD = sum(FDD)
+    return sqrt(sFDD)
+end
+@inline function norm{T <: SIMDTypes}(S::SymmetricTensor{4, 3, T})
+    F = SVec{36, T}((T(1), T(2), T(2), T(1), T(2), T(1), T(2), T(4), T(4), T(2), T(4), T(2),
+                     T(2), T(4), T(4), T(2), T(4), T(2), T(1), T(2), T(2), T(1), T(2), T(1),
+                     T(2), T(4), T(4), T(2), T(4), T(2), T(1), T(2), T(2), T(1), T(2), T(1)))
+    D = SVec{36, T}(get_data(S))
+    DD = D * D; FDD = F * DD; sFDD = sum(FDD)
+    return sqrt(sFDD)
+end
+
+# dcontract
+@inline dcontract{dim, T <: SIMDTypes}(S1::SecondOrderTensor{dim, T}, S2::SecondOrderTensor{dim, T}) = dcontract(promote(S1, S2)...)
+
+@inline function dcontract{T <: SIMDTypes}(S1::Tensor{2, 3, T}, S2::Tensor{2, 3, T})
+    D1 = SVec{9, T}(get_data(S1))
+    D2 = SVec{9, T}(get_data(S2))
+    D1D2 = D1 * D2
+    return sum(D1D2)
+end
+
+@inline function dcontract{T <: SIMDTypes}(S1::SymmetricTensor{2, 3, T}, S2::SymmetricTensor{2, 3, T})
+    D1 = SVec{6, T}(get_data(S1))
+    D2 = SVec{6, T}(get_data(S2))
+    F  = SVec{6, T}((T(1), T(2), T(2), T(1), T(2), T(1)))
+    D1D2 = D1 * D2; FD1D2 = F * D1D2
+    return sum(FD1D2)
+end
+
+@inline function dcontract{T <: SIMDTypes}(S1::Tensor{4, 1, T}, S2::Tensor{2, 1, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+        D11 = SVec{4, T}((D1[1], ))
+        r  = D11 * D2[1]
+        return Tensor{2, 1}((r[1], ))
+    end
+end
+
+@inline function dcontract{T <: SIMDTypes}(S1::Tensor{4, 2, T}, S2::Tensor{2, 2, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+
+        D11 = SVec{4, T}((D1[1],  D1[2],  D1[3],  D1[4]))
+        D12 = SVec{4, T}((D1[5],  D1[6],  D1[7],  D1[8]))
+        D13 = SVec{4, T}((D1[9],  D1[10], D1[11], D1[12]))
+        D14 = SVec{4, T}((D1[13], D1[14], D1[15], D1[16]))
+
+        r  = D11 * D2[1]
+        r += D12 * D2[2]
+        r += D13 * D2[3]
+        r += D14 * D2[4]
+
+        return Tensor{2, 2}((r[1], r[2], r[3], r[4]))
+    end
+end
+
+@inline function dcontract{T <: SIMDTypes}(S1::Tensor{4,3,T}, S2::Tensor{2,3,T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+
+        D11 = SVec{9, T}((D1[1],  D1[2],  D1[3],  D1[4],  D1[5],  D1[6],  D1[7],  D1[8],  D1[9]))
+        D12 = SVec{9, T}((D1[10], D1[11], D1[12], D1[13], D1[14], D1[15], D1[16], D1[17], D1[18]))
+        D13 = SVec{9, T}((D1[19], D1[20], D1[21], D1[22], D1[23], D1[24], D1[25], D1[26], D1[27]))
+        D14 = SVec{9, T}((D1[28], D1[29], D1[30], D1[31], D1[32], D1[33], D1[34], D1[35], D1[36]))
+        D15 = SVec{9, T}((D1[37], D1[38], D1[39], D1[40], D1[41], D1[42], D1[43], D1[44], D1[45]))
+        D16 = SVec{9, T}((D1[46], D1[47], D1[48], D1[49], D1[50], D1[51], D1[52], D1[53], D1[54]))
+        D17 = SVec{9, T}((D1[55], D1[56], D1[57], D1[58], D1[59], D1[60], D1[61], D1[62], D1[63]))
+        D18 = SVec{9, T}((D1[64], D1[65], D1[66], D1[67], D1[68], D1[69], D1[70], D1[71], D1[72]))
+        D19 = SVec{9, T}((D1[73], D1[74], D1[75], D1[76], D1[77], D1[78], D1[79], D1[80], D1[81]))
+
+        r  = D11 * D2[1]
+        r += D12 * D2[2]
+        r += D13 * D2[3]
+        r += D14 * D2[4]
+        r += D15 * D2[5]
+        r += D16 * D2[6]
+        r += D17 * D2[7]
+        r += D18 * D2[8]
+        r += D19 * D2[9]
+
+        return Tensor{2, 3}((r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]))
+    end
+end
+
+# @inline dcontract2{T <: SIMDTypes}(S1::Tensor{2, 2, T}, S2::Tensor{4, 2, T}) = dcontract(majortranspose(S2), S1)
+
+# @inline function dcontract4{T <: SIMDTypes}(S1::Tensor{2, 2, T}, S2::Tensor{4, 2, T})
+#     @inbounds begin
+        # D1 = get_data(S1)
+        # D2 = get_data(S2)
+
+#         D1 = SVec{4, T}((D1[1],  D1[2],  D1[3],  D1[4]))
+#         D21 = SVec{4, T}((D2[1],  D2[2],  D2[3],  D2[4]))
+#         D22 = SVec{4, T}((D2[5],  D2[6],  D2[7],  D2[8]))
+#         D23 = SVec{4, T}((D2[9],  D2[10], D2[11], D2[12]))
+#         D24 = SVec{4, T}((D2[13], D2[14], D2[15], D2[16]))
+
+#         D1D21 = D1 * D21
+#         r1  = sum(D1D21)
+#         D1D22 = D1 * D22
+#         r2  = sum(D1D22)
+#         D1D23 = D1 * D23
+#         r3  = sum(D1D23)
+#         D1D24 = D1 * D24
+#         r4  = sum(D1D24)
+
+#         return Tensor{2, 2}((r1, r2, r3, r4))
+#     end
+# end
+
+# @inline function dcontract3{T <: SIMDTypes}(S1::Tensor{2, 2, T}, S2::Tensor{4, 2, T})
+#     @inbounds begin
+        # D1 = get_data(S1)
+        # D2 = get_data(S2)
+
+#         D21 = SVec{4, T}((D2[1], D2[5], D2[9],  D2[13]))
+#         D22 = SVec{4, T}((D2[2], D2[6], D2[10], D2[14]))
+#         D23 = SVec{4, T}((D2[3], D2[7], D2[11], D2[15]))
+#         D24 = SVec{4, T}((D2[4], D2[8], D2[12], D2[16]))
+
+#         r  = D21 * D1[1]
+#         r += D22 * D1[2]
+#         r += D23 * D1[3]
+#         r += D24 * D1[4]
+
+#         return Tensor{2, 2}((r[1], r[2], r[3], r[4]))
+#     end
+# end
+
+@inline function dcontract{T <: SIMDTypes}(S1::Tensor{4, 1, T}, S2::Tensor{4, 1, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+        D11 = SVec{1, T}((D1[1], ))
+        r1  = D11 * D2[1]
+        return Tensor{4, 1}((r1[1], ))
+    end
+end
+
+@inline function dcontract{T <: SIMDTypes}(S1::Tensor{4, 2, T}, S2::Tensor{4, 2, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+
+        D11 = SVec{4, T}((D1[1],  D1[2],  D1[3],  D1[4]))
+        D12 = SVec{4, T}((D1[5],  D1[6],  D1[7],  D1[8]))
+        D13 = SVec{4, T}((D1[9],  D1[10], D1[11], D1[12]))
+        D14 = SVec{4, T}((D1[13], D1[14], D1[15], D1[16]))
+
+        r1  = D11 * D2[1]
+        r1 += D12 * D2[2]
+        r1 += D13 * D2[3]
+        r1 += D14 * D2[4]
+
+        r2  = D11 * D2[5]
+        r2 += D12 * D2[6]
+        r2 += D13 * D2[7]
+        r2 += D14 * D2[8]
+
+        r3  = D11 * D2[9]
+        r3 += D12 * D2[10]
+        r3 += D13 * D2[11]
+        r3 += D14 * D2[12]
+
+        r4  = D11 * D2[13]
+        r4 += D12 * D2[14]
+        r4 += D13 * D2[15]
+        r4 += D14 * D2[16]
+
+        return Tensor{4, 2}((r1[1],  r1[2],  r1[3],  r1[4],
+                             r2[1],  r2[2],  r2[3],  r2[4],
+                             r3[1],  r3[2],  r3[3],  r3[4],
+                             r4[1],  r4[2],  r4[3],  r4[4]))
+    end
+end
+
+@inline function dcontract{T <: SIMDTypes}(S1::Tensor{4, 3, T}, S2::Tensor{4, 3, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+
+        D11 = SVec{9, T}((D1[1],  D1[2],  D1[3],  D1[4],  D1[5],  D1[6],  D1[7],  D1[8],  D1[9]))
+        D12 = SVec{9, T}((D1[10], D1[11], D1[12], D1[13], D1[14], D1[15], D1[16], D1[17], D1[18]))
+        D13 = SVec{9, T}((D1[19], D1[20], D1[21], D1[22], D1[23], D1[24], D1[25], D1[26], D1[27]))
+        D14 = SVec{9, T}((D1[28], D1[29], D1[30], D1[31], D1[32], D1[33], D1[34], D1[35], D1[36]))
+        D15 = SVec{9, T}((D1[37], D1[38], D1[39], D1[40], D1[41], D1[42], D1[43], D1[44], D1[45]))
+        D16 = SVec{9, T}((D1[46], D1[47], D1[48], D1[49], D1[50], D1[51], D1[52], D1[53], D1[54]))
+        D17 = SVec{9, T}((D1[55], D1[56], D1[57], D1[58], D1[59], D1[60], D1[61], D1[62], D1[63]))
+        D18 = SVec{9, T}((D1[64], D1[65], D1[66], D1[67], D1[68], D1[69], D1[70], D1[71], D1[72]))
+        D19 = SVec{9, T}((D1[73], D1[74], D1[75], D1[76], D1[77], D1[78], D1[79], D1[80], D1[81]))
+
+        r1  = D11 * D2[1]
+        r1 += D12 * D2[2]
+        r1 += D13 * D2[3]
+        r1 += D14 * D2[4]
+        r1 += D15 * D2[5]
+        r1 += D16 * D2[6]
+        r1 += D17 * D2[7]
+        r1 += D18 * D2[8]
+        r1 += D19 * D2[9]
+
+        r2  = D11 * D2[10]
+        r2 += D12 * D2[11]
+        r2 += D13 * D2[12]
+        r2 += D14 * D2[13]
+        r2 += D15 * D2[14]
+        r2 += D16 * D2[15]
+        r2 += D17 * D2[16]
+        r2 += D18 * D2[17]
+        r2 += D19 * D2[18]
+
+        r3  = D11 * D2[19]
+        r3 += D12 * D2[20]
+        r3 += D13 * D2[21]
+        r3 += D14 * D2[22]
+        r3 += D15 * D2[23]
+        r3 += D16 * D2[24]
+        r3 += D17 * D2[25]
+        r3 += D18 * D2[26]
+        r3 += D19 * D2[27]
+
+        r4  = D11 * D2[28]
+        r4 += D12 * D2[29]
+        r4 += D13 * D2[30]
+        r4 += D14 * D2[31]
+        r4 += D15 * D2[32]
+        r4 += D16 * D2[33]
+        r4 += D17 * D2[34]
+        r4 += D18 * D2[35]
+        r4 += D19 * D2[36]
+
+        r5  = D11 * D2[37]
+        r5 += D12 * D2[38]
+        r5 += D13 * D2[39]
+        r5 += D14 * D2[40]
+        r5 += D15 * D2[41]
+        r5 += D16 * D2[42]
+        r5 += D17 * D2[43]
+        r5 += D18 * D2[44]
+        r5 += D19 * D2[45]
+
+        r6  = D11 * D2[46]
+        r6 += D12 * D2[47]
+        r6 += D13 * D2[48]
+        r6 += D14 * D2[49]
+        r6 += D15 * D2[50]
+        r6 += D16 * D2[51]
+        r6 += D17 * D2[52]
+        r6 += D18 * D2[53]
+        r6 += D19 * D2[54]
+
+        r7  = D11 * D2[55]
+        r7 += D12 * D2[56]
+        r7 += D13 * D2[57]
+        r7 += D14 * D2[58]
+        r7 += D15 * D2[59]
+        r7 += D16 * D2[60]
+        r7 += D17 * D2[61]
+        r7 += D18 * D2[62]
+        r7 += D19 * D2[63]
+
+        r8  = D11 * D2[64]
+        r8 += D12 * D2[65]
+        r8 += D13 * D2[66]
+        r8 += D14 * D2[67]
+        r8 += D15 * D2[68]
+        r8 += D16 * D2[69]
+        r8 += D17 * D2[70]
+        r8 += D18 * D2[71]
+        r8 += D19 * D2[72]
+
+        r9  = D11 * D2[73]
+        r9 += D12 * D2[74]
+        r9 += D13 * D2[75]
+        r9 += D14 * D2[76]
+        r9 += D15 * D2[77]
+        r9 += D16 * D2[78]
+        r9 += D17 * D2[79]
+        r9 += D18 * D2[80]
+        r9 += D19 * D2[81]
+
+        return Tensor{4, 3}((r1[1], r1[2], r1[3], r1[4], r1[5], r1[6], r1[7], r1[8], r1[9],
+                             r2[1], r2[2], r2[3], r2[4], r2[5], r2[6], r2[7], r2[8], r2[9],
+                             r3[1], r3[2], r3[3], r3[4], r3[5], r3[6], r3[7], r3[8], r3[9],
+                             r4[1], r4[2], r4[3], r4[4], r4[5], r4[6], r4[7], r4[8], r4[9],
+                             r5[1], r5[2], r5[3], r5[4], r5[5], r5[6], r5[7], r5[8], r5[9],
+                             r6[1], r6[2], r6[3], r6[4], r6[5], r6[6], r6[7], r6[8], r6[9],
+                             r7[1], r7[2], r7[3], r7[4], r7[5], r7[6], r7[7], r7[8], r7[9],
+                             r8[1], r8[2], r8[3], r8[4], r8[5], r8[6], r8[7], r8[8], r8[9],
+                             r9[1], r9[2], r9[3], r9[4], r9[5], r9[6], r9[7], r9[8], r9[9]))
+    end
+end
+
+# otimes
+@inline function otimes{T <: SIMDTypes}(S1::Vec{1, T}, S2::Vec{1, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+
+        D11 = SVec{1, T}((D1[1], ))
+
+        r1 = D11 * D2[1]
+
+        return Tensor{2, 1}((r1[1], ))
+    end
+end
+
+@inline function otimes{T <: SIMDTypes}(S1::Vec{2, T}, S2::Vec{2, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+
+        D11 = SVec{2, T}((D1[1], D1[2]))
+
+        r1 = D11 * D2[1]
+        r2 = D11 * D2[2]
+
+        return Tensor{2, 2}((r1[1], r1[2], r2[1], r2[2]))
+    end
+end
+
+@inline function otimes{T <: SIMDTypes}(S1::Vec{3, T}, S2::Vec{3, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+
+        D11 = SVec{3, T}((D1[1], D1[2], D1[3]))
+
+        r1 = D11 * D2[1]
+        r2 = D11 * D2[2]
+        r3 = D11 * D2[3]
+
+        return Tensor{2, 3}((r1[1], r1[2], r1[3],
+                             r2[1], r2[2], r2[3],
+                             r3[1], r3[2], r3[3]))
+    end
+end
+
+@inline function otimes{T <: SIMDTypes}(S1::Tensor{2, 1, T}, S2::Tensor{2, 1, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+
+        D11 = SVec{1, T}((D1[1], ))
+
+        r1 = D11 * D2[1]
+
+        return Tensor{4, 1}((r1[1], ))
+    end
+end
+
+@inline function otimes{T <: SIMDTypes}(S1::Tensor{2, 2, T}, S2::Tensor{2, 2, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+
+        D11 = SVec{4, T}((D1[1], D1[2], D1[3], D1[4]))
+
+        r1 = D11 * D2[1]
+        r2 = D11 * D2[2]
+        r3 = D11 * D2[3]
+        r4 = D11 * D2[4]
+
+        return Tensor{4, 2}((r1[1], r1[2], r1[3], r1[4],
+                             r2[1], r2[2], r2[3], r2[4],
+                             r3[1], r3[2], r3[3], r3[4],
+                             r4[1], r4[2], r4[3], r4[4]))
+    end
+end
+
+@inline function otimes{T <: SIMDTypes}(S1::Tensor{2, 3, T}, S2::Tensor{2, 3, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+
+        D11 = SVec{9, T}((D1[1], D1[2], D1[3], D1[4], D1[5], D1[6], D1[7], D1[8], D1[9]))
+
+        r1 = D11 * D2[1]
+        r2 = D11 * D2[2]
+        r3 = D11 * D2[3]
+        r4 = D11 * D2[4]
+        r5 = D11 * D2[5]
+        r6 = D11 * D2[6]
+        r7 = D11 * D2[7]
+        r8 = D11 * D2[8]
+        r9 = D11 * D2[9]
+
+        return Tensor{4, 3}((r1[1], r1[2], r1[3], r1[4], r1[5], r1[6], r1[7], r1[8], r1[9],
+                             r2[1], r2[2], r2[3], r2[4], r2[5], r2[6], r2[7], r2[8], r2[9],
+                             r3[1], r3[2], r3[3], r3[4], r3[5], r3[6], r3[7], r3[8], r3[9],
+                             r4[1], r4[2], r4[3], r4[4], r4[5], r4[6], r4[7], r4[8], r4[9],
+                             r5[1], r5[2], r5[3], r5[4], r5[5], r5[6], r5[7], r5[8], r5[9],
+                             r6[1], r6[2], r6[3], r6[4], r6[5], r6[6], r6[7], r6[8], r6[9],
+                             r7[1], r7[2], r7[3], r7[4], r7[5], r7[6], r7[7], r7[8], r7[9],
+                             r8[1], r8[2], r8[3], r8[4], r8[5], r8[6], r8[7], r8[8], r8[9],
+                             r9[1], r9[2], r9[3], r9[4], r9[5], r9[6], r9[7], r9[8], r9[9]))
+    end
+end
+
+@inline function +{T <: SIMDTypes}(S1::Tensor{2, 3, T}, S2::Tensor{2, 3, T})
+    @inbounds begin
+        D1 = SVec{9, T}(get_data(S1))
+        D2 = SVec{9, T}(get_data(S2))
+
+        r = D1 + D2
+
+        return Tensor{2, 3}((r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]))
+    end
+end
+
+@inline function -{T <: SIMDTypes}(S1::Tensor{2, 3, T}, S2::Tensor{2, 3, T})
+    @inbounds begin
+        D1 = SVec{9, T}(get_data(S1))
+        D2 = SVec{9, T}(get_data(S2))
+
+        r = D1 - D2
+
+        return Tensor{2, 3}((r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]))
+    end
+end
+
+@inline function mul{T <: SIMDTypes}(n::T, S2::Tensor{2, 3, T})
+    @inbounds begin
+        D2 = SVec{9, T}(get_data(S2))
+
+        r = n * D2
+
+        return Tensor{2, 3}((r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]))
+    end
+end
+
+@inline function mul{T <: SIMDTypes}(S1::Tensor{2, 3, T}, n::T)
+    @inbounds begin
+        D1 = SVec{9, T}(get_data(S1))
+
+        r = D1 * n
+
+        return Tensor{2, 3}((r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]))
+    end
+end
+
+
+end # module

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -60,8 +60,7 @@ end
         SymmetricTensor{$order, $dim}($(Expr(:tuple, [:(r[$i]) for i in 1:N]...)))
     end
 end
-
-# constructor from several SVecs which happens in dot and dcontract
+# constructor from several SVecs which happens in dot, dcontract and otimes
 @generated function (::Type{Tensor{order, dim}}){order, dim, M, N, T}(r::NTuple{M, SVec{N, T}})
     return quote
         $(Expr(:meta, :inline))
@@ -385,7 +384,7 @@ end
         return Tensor{4, 2}((r1, r2, r3, r4))
     end
 end
-@inline function dcontract2{T <: SIMDTypes}(S1::Tensor{4, 3, T}, S2::Tensor{4, 3, T})
+@inline function dcontract{T <: SIMDTypes}(S1::Tensor{4, 3, T}, S2::Tensor{4, 3, T})
     @inbounds begin
         D1 = get_data(S1)
         D2 = get_data(S2)

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -23,8 +23,8 @@ import SIMD
 @compat const SVec{N, T} = SIMD.Vec{N, T}
 
 const SIMDTypes = Union{Bool,
-                        Int8, Int16, Int32, Int32, Int128,
-                        UInt8, UInt16, UInt32, UInt32, UInt128,
+                        Int8, Int16, Int32, Int64, Int128,
+                        UInt8, UInt16, UInt32, UInt64, UInt128,
                         Float16, Float32, Float64}
 
 @compat const AllSIMDTensors{dim, T <: SIMDTypes} = AllTensors{dim, T}

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -92,16 +92,12 @@ end
 ################################
 # (1): + and - between tensors #
 ################################
-@generated function Base.:+{TT <: AllSIMDTensors}(S1::TT, S2::TT)
-    TensorType = get_base(S1)
-    return quote
-        $(Expr(:meta, :inline))
-        @inbounds begin
-            D1 = get_data(S1); SV1 = tosimd(D1)
-            D2 = get_data(S2); SV2 = tosimd(D2)
-            r = SV1 + SV2
-            return $TensorType(r)
-        end
+@inline function Base.:+{TT <: AllSIMDTensors}(S1::TT, S2::TT)
+    @inbounds begin
+        D1 = get_data(S1); SV1 = tosimd(D1)
+        D2 = get_data(S2); SV2 = tosimd(D2)
+        r = SV1 + SV2
+        return get_base(TT)(r)
     end
 end
 @generated function Base.:+{T <: SIMDTypes}(S1::Tensor{4, 3, T}, S2::Tensor{4, 3, T})
@@ -116,16 +112,12 @@ end
         end
     end
 end
-@generated function Base.:-{TT <: AllSIMDTensors}(S1::TT, S2::TT)
-    TensorType = get_base(S1)
-    return quote
-        $(Expr(:meta, :inline))
-        @inbounds begin
-            D1 = get_data(S1); SV1 = tosimd(D1)
-            D2 = get_data(S2); SV2 = tosimd(D2)
-            r = SV1 - SV2
-            return $TensorType(r)
-        end
+@inline function Base.:-{TT <: AllSIMDTensors}(S1::TT, S2::TT)
+    @inbounds begin
+        D1 = get_data(S1); SV1 = tosimd(D1)
+        D2 = get_data(S2); SV2 = tosimd(D2)
+        r = SV1 - SV2
+        return get_base(TT)(r)
     end
 end
 @generated function Base.:-{T <: SIMDTypes}(S1::Tensor{4, 3, T}, S2::Tensor{4, 3, T})
@@ -144,16 +136,11 @@ end
 ##########################################
 # (2): * and / between tensor and number #
 ##########################################
-# note it is allowed with different eltypes, since it is promoted in SIMD.jl
-@generated function Base.:*{T <: SIMDTypes}(n::T, S::AllSIMDTensors{T})
-    TensorType = get_base(S)
-    return quote
-        $(Expr(:meta, :inline))
-        @inbounds begin
-            D = get_data(S); SV = tosimd(D)
-            r = n * SV
-            return $TensorType(r)
-        end
+@inline function Base.:*{T <: SIMDTypes}(n::T, S::AllSIMDTensors{T})
+    @inbounds begin
+        D = get_data(S); SV = tosimd(D)
+        r = n * SV
+        return get_base(typeof(S))(r)
     end
 end
 @generated function Base.:*{T <: SIMDTypes}(n::T, S::Tensor{4, 3, T})
@@ -166,15 +153,11 @@ end
         end
     end
 end
-@generated function Base.:*{T <: SIMDTypes}(S::AllSIMDTensors{T}, n::T)
-    TensorType = get_base(S)
-    return quote
-        $(Expr(:meta, :inline))
-        @inbounds begin
-            D = get_data(S); SV = tosimd(D)
-            r = SV * n
-            return $TensorType(r)
-        end
+@inline function Base.:*{T <: SIMDTypes}(S::AllSIMDTensors{T}, n::T)
+    @inbounds begin
+        D = get_data(S); SV = tosimd(D)
+        r = SV * n
+        return get_base(typeof(S))(r)
     end
 end
 @generated function Base.:*{T <: SIMDTypes}(S::Tensor{4, 3, T}, n::T)
@@ -187,15 +170,11 @@ end
         end
     end
 end
-@generated function Base.:/{T <: SIMDTypes}(S::AllSIMDTensors{T}, n::T)
-    TensorType = get_base(S)
-    return quote
-        $(Expr(:meta, :inline))
-        @inbounds begin
-            D = get_data(S); SV = tosimd(D)
-            r = SV / n
-            return $TensorType(r)
-        end
+@inline function Base.:/{T <: SIMDTypes}(S::AllSIMDTensors{T}, n::T)
+    @inbounds begin
+        D = get_data(S); SV = tosimd(D)
+        r = SV / n
+        return get_base(typeof(S))(r)
     end
 end
 @generated function Base.:/{T <: SIMDTypes}(S::Tensor{4, 3, T}, n::T)
@@ -409,7 +388,7 @@ end
 # (6): norm #
 #############
 # order 1 and order 2 norms rely on dot and dcontract respectively
-@inline function Base.norm{T <: SIMDTypes, N}(S::Tensor{4, 2, T, N})
+@inline function Base.norm{T <: SIMDTypes}(S::Tensor{4, 2, T})
     @inbounds begin
         SV = tosimd(get_data(S))
         SVSV = SV * SV
@@ -430,7 +409,7 @@ end
         end
     end
 end
-@generated function Base.norm{dim, T <: SIMDTypes, N}(S::SymmetricTensor{4, dim, T, N})
+@generated function Base.norm{dim, T <: SIMDTypes}(S::SymmetricTensor{4, dim, T})
     F = symmetric_factors(4, dim, T)
     return quote
         $(Expr(:meta, :inline))

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -28,7 +28,7 @@ const SIMDTypes = Union{Bool,
                         UInt8, UInt16, UInt32, UInt64, UInt128,
                         Float16, Float32, Float64}
 
-@compat const AllSIMDTensors{dim, T <: SIMDTypes} = AllTensors{dim, T}
+@compat const AllSIMDTensors{T <: SIMDTypes, dim} = AllTensors{dim, T} # T more useful so swapping
 
 # SIMD sizes accepted by LLVM between 1 and 100
 const SIMD_CHUNKS = (1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 16, 17, 18, 20, 24, 32, 33, 34, 36, 40, 48, 64, 65, 66, 68, 72, 80, 96)
@@ -138,72 +138,72 @@ end
 ##########################################
 # (2): * and / between tensor and number #
 ##########################################
-@generated function Base.:*{dim, T <: SIMDTypes}(n::T, S::AllTensors{dim, T})
+@generated function Base.:*{T1 <: SIMDTypes, T2 <: SIMDTypes}(n::T1, S::AllSIMDTensors{T2})
     TensorType = get_base(S)
     N = n_components(TensorType)
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
-            D = SVec{$N, T}(get_data(S))
+            D = SVec{$N, T2}(get_data(S))
             r = n * D
             return $TensorType(r)
         end
     end
 end
-@generated function Base.:*{T <: SIMDTypes}(n::T, S::Tensor{4, 3, T})
+@generated function Base.:*{T1 <: SIMDTypes, T2 <: SIMDTypes}(n::T1, S::Tensor{4, 3, T2})
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
             D = get_data(S)
-            D80 = SVec{80, T}($(Expr(:tuple, [:(D[$i]) for i in 1:80]...)))
+            D80 = SVec{80, T2}($(Expr(:tuple, [:(D[$i]) for i in 1:80]...)))
             r = n * D80
             r81 = n * D[81]
             return Tensor{4, 3}($(Expr(:tuple, [:(r[$i]) for i in 1:80]..., :(r81))))
         end
     end
 end
-@generated function Base.:*{dim, T <: SIMDTypes}(S::AllTensors{dim, T}, n::T)
+@generated function Base.:*{T1 <: SIMDTypes, T2 <: SIMDTypes}(S::AllSIMDTensors{T1}, n::T2)
     TensorType = get_base(S)
     N = n_components(TensorType)
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
-            D = SVec{$N, T}(get_data(S))
+            D = SVec{$N, T1}(get_data(S))
             r = D * n
             return $TensorType(r)
         end
     end
 end
-@generated function Base.:*{T <: SIMDTypes}(S::Tensor{4, 3, T}, n::T)
+@generated function Base.:*{T1 <: SIMDTypes, T2 <: SIMDTypes}(S::Tensor{4, 3, T1}, n::T2)
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
             D = get_data(S)
-            D80 = SVec{80, T}($(Expr(:tuple, [:(D[$i]) for i in 1:80]...)))
+            D80 = SVec{80, T1}($(Expr(:tuple, [:(D[$i]) for i in 1:80]...)))
             r = D80 * n
             r81 = D[81] * n
             return Tensor{4, 3}($(Expr(:tuple, [:(r[$i]) for i in 1:80]..., :(r81))))
         end
     end
 end
-@generated function Base.:/{dim, T <: SIMDTypes}(S::AllTensors{dim, T}, n::T)
+@generated function Base.:/{T1 <: SIMDTypes, T2 <: SIMDTypes}(S::AllSIMDTensors{T1}, n::T2)
     TensorType = get_base(S)
     N = n_components(TensorType)
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
-            D = SVec{$N, T}(get_data(S))
+            D = SVec{$N, T1}(get_data(S))
             r = D / n
             return $TensorType(r)
         end
     end
 end
-@generated function Base.:/{T <: SIMDTypes}(S::Tensor{4, 3, T}, n::T)
+@generated function Base.:/{T1 <: SIMDTypes, T2 <: SIMDTypes}(S::Tensor{4, 3, T1}, n::T2)
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
             D = get_data(S)
-            D80 = SVec{80, T}($(Expr(:tuple, [:(D[$i]) for i in 1:80]...)))
+            D80 = SVec{80, T1}($(Expr(:tuple, [:(D[$i]) for i in 1:80]...)))
             r = D80 / n
             r81 = D[81] / n
             return Tensor{4, 3}($(Expr(:tuple, [:(r[$i]) for i in 1:80]..., :(r81))))
@@ -221,20 +221,18 @@ end
         D2 = get_data(S2)
         D11 = SVec{2, T}((D1[1], D1[2]))
         D12 = SVec{2, T}((D1[3], D1[4]))
-        r1 = D11 * D2[1]; r2 = D12 * D2[2]
-        r = r1 + r2
+        r = fma(D12, D2[2], D11 * D2[1])
         return Tensor{1, 2}(r)
     end
 end
-@inline function Base.dot{T <: SIMDTypes, N}(S1::Tensor{2, 3, T, N}, S2::Vec{3, T})
+@inline function Base.dot{T <: SIMDTypes}(S1::Tensor{2, 3, T}, S2::Vec{3, T})
     @inbounds begin
         D1 = get_data(S1)
         D2 = get_data(S2)
         D11 = SVec{3, T}((D1[1], D1[2], D1[3]))
         D12 = SVec{3, T}((D1[4], D1[5], D1[6]))
         D13 = SVec{3, T}((D1[7], D1[8], D1[9]))
-        r1 = D11 * D2[1]; r2 = D12 * D2[2]; r3 = D13 * D2[3]
-        r12 = r1 + r2; r = r12 + r3
+        r = fma(D13, D2[3], fma(D12, D2[2], D11 * D2[1]))
         return Tensor{1, 3}(r)
     end
 end
@@ -246,9 +244,9 @@ end
         D2 = get_data(S2)
         D11 = SVec{2, T}((D1[1], D1[2]))
         D12 = SVec{2, T}((D1[3], D1[4]))
-        r1 = D11 * D2[1]; r2 = D12 * D2[2]; r12 = r1 + r2
-        r3 = D11 * D2[3]; r4 = D12 * D2[4]; r34 = r3 + r4
-        return Tensor{2, 2}((r12, r34))
+        r1 = fma(D12, D2[2], D11 * D2[1])
+        r2 = fma(D12, D2[4], D11 * D2[3])
+        return Tensor{2, 2}((r1, r2))
     end
 end
 @inline function Base.dot{T <: SIMDTypes}(S1::Tensor{2, 3, T}, S2::Tensor{2, 3, T})
@@ -258,13 +256,10 @@ end
         D11 = SVec{3, T}((D1[1], D1[2], D1[3]))
         D12 = SVec{3, T}((D1[4], D1[5], D1[6]))
         D13 = SVec{3, T}((D1[7], D1[8], D1[9]))
-        r1 = D11 * D2[1]; r2 = D12 * D2[2]; r3 = D13 * D2[3]
-        r12 = r1 + r2; r123 = r12 + r3
-        r4 = D11 * D2[4]; r5 = D12 * D2[5]; r6 = D13 * D2[6]
-        r45 = r4 + r5; r456 = r45 + r6
-        r7 = D11 * D2[7]; r8 = D12 * D2[8]; r9 = D13 * D2[9]
-        r78 = r7 + r8; r789 = r78 + r9
-        return Tensor{2, 3}((r123, r456, r789))
+        r1 = fma(D13, D2[3], fma(D12, D2[2], D11 * D2[1]))
+        r2 = fma(D13, D2[6], fma(D12, D2[5], D11 * D2[4]))
+        r3 = fma(D13, D2[9], fma(D12, D2[8], D11 * D2[7]))
+        return Tensor{2, 3}((r1, r2, r3))
     end
 end
 
@@ -300,13 +295,11 @@ end
         D12 = SVec{4, T}((D1[5],  D1[6],  D1[7],  D1[8]))
         D13 = SVec{4, T}((D1[9],  D1[10], D1[11], D1[12]))
         D14 = SVec{4, T}((D1[13], D1[14], D1[15], D1[16]))
-        r1 = D11 * D2[1]; r2 = D12 * D2[2]
-        r3 = D13 * D2[3]; r4 = D14 * D2[4]
-        r12 = r1 + r2; r34 = r3 + r4; r = r12 + r34
+        r = fma(D14, D2[4], fma(D13, D2[3], fma(D12, D2[2], D11 * D2[1])))
         return Tensor{2, 2}(r)
     end
 end
-@inline function Tensors.dcontract{T <: SIMDTypes}(S1::Tensor{4,3,T}, S2::Tensor{2,3,T})
+@inline function Tensors.dcontract{T <: SIMDTypes}(S1::Tensor{4, 3, T}, S2::Tensor{2, 3, T})
     @inbounds begin
         D1 = get_data(S1)
         D2 = get_data(S2)
@@ -319,13 +312,8 @@ end
         D17 = SVec{9, T}((D1[55], D1[56], D1[57], D1[58], D1[59], D1[60], D1[61], D1[62], D1[63]))
         D18 = SVec{9, T}((D1[64], D1[65], D1[66], D1[67], D1[68], D1[69], D1[70], D1[71], D1[72]))
         D19 = SVec{9, T}((D1[73], D1[74], D1[75], D1[76], D1[77], D1[78], D1[79], D1[80], D1[81]))
-        r1 = D11 * D2[1]; r2 = D12 * D2[2]; r3 = D13 * D2[3]
-        r4 = D14 * D2[4]; r5 = D15 * D2[5]; r6 = D16 * D2[6]
-        r7 = D17 * D2[7]; r8 = D18 * D2[8]; r9 = D19 * D2[9]
-        r12 = r1 + r2; r34 = r3 + r4; r56 = r5 + r6; r78 = r7 + r8
-        r1234 = r12 + r34; r5678 = r56 + r78; r12345678 = r1234 + r5678
-        r = r12345678 + r9
-        return Tensor{2, 3}(r)
+        r = fma(D19, D2[9],  fma(D18, D2[8],  fma(D17, D2[7],  fma(D16, D2[6],  fma(D15, D2[5],  fma(D14, D2[4],  fma(D13, D2[3],  fma(D12, D2[2],  D11 * D2[1]))))))))
+        return return Tensor{2, 3}(r)
     end
 end
 
@@ -338,14 +326,10 @@ end
         D12 = SVec{4, T}((D1[5],  D1[6],  D1[7],  D1[8]))
         D13 = SVec{4, T}((D1[9],  D1[10], D1[11], D1[12]))
         D14 = SVec{4, T}((D1[13], D1[14], D1[15], D1[16]))
-        r11 = D11 * D2[1]; r12 = D12 * D2[2]; r13 = D13 * D2[3]; r14 = D14 * D2[4]
-        r112 = r11 + r12; r134 = r13 + r14; r1 = r112 + r134
-        r21 = D11 * D2[5]; r22 = D12 * D2[6]; r23 = D13 * D2[7]; r24 = D14 * D2[8]
-        r212 = r21 + r22; r234 = r23 + r24; r2 = r212 + r234
-        r31 = D11 * D2[9]; r32 = D12 * D2[10]; r33 = D13 * D2[11]; r34 = D14 * D2[12]
-        r312 = r31 + r32; r334 = r33 + r34; r3 = r312 + r334
-        r41 = D11 * D2[13]; r42 = D12 * D2[14]; r43 = D13 * D2[15]; r44 = D14 * D2[16]
-        r412 = r41 + r42; r434 = r43 + r44; r4 = r412 + r434
+        r1 = fma(D14, D2[4],  fma(D13, D2[3],  fma(D12, D2[2],  D11 * D2[1])))
+        r2 = fma(D14, D2[8],  fma(D13, D2[7],  fma(D12, D2[6],  D11 * D2[5])))
+        r3 = fma(D14, D2[12], fma(D13, D2[11], fma(D12, D2[10], D11 * D2[9])))
+        r4 = fma(D14, D2[16], fma(D13, D2[15], fma(D12, D2[14], D11 * D2[13])))
         return Tensor{4, 2}((r1, r2, r3, r4))
     end
 end
@@ -362,60 +346,15 @@ end
         D17 = SVec{9, T}((D1[55], D1[56], D1[57], D1[58], D1[59], D1[60], D1[61], D1[62], D1[63]))
         D18 = SVec{9, T}((D1[64], D1[65], D1[66], D1[67], D1[68], D1[69], D1[70], D1[71], D1[72]))
         D19 = SVec{9, T}((D1[73], D1[74], D1[75], D1[76], D1[77], D1[78], D1[79], D1[80], D1[81]))
-        r11 = D11 * D2[1]; r12 = D12 * D2[2]; r13 = D13 * D2[3]
-        r14 = D14 * D2[4]; r15 = D15 * D2[5]; r16 = D16 * D2[6]
-        r17 = D17 * D2[7]; r18 = D18 * D2[8]; r19 = D19 * D2[9]
-        r112 = r11 + r12; r134 = r13 + r14; r156 = r15 + r16; r178 = r17 + r18
-        r11234 = r112 + r134; r15678 = r156 + r178; r112345678 = r11234 + r15678
-        r1 = r112345678 + r19
-        r21 = D11 * D2[10]; r22 = D12 * D2[11]; r23 = D13 * D2[12]
-        r24 = D14 * D2[13]; r25 = D15 * D2[14]; r26 = D16 * D2[15]
-        r27 = D17 * D2[16]; r28 = D18 * D2[17]; r29 = D19 * D2[18]
-        r212 = r21 + r22; r234 = r23 + r24; r256 = r25 + r26; r278 = r27 + r28
-        r21234 = r212 + r234; r25678 = r256 + r278; r212345678 = r21234 + r25678
-        r2 = r212345678 + r29
-        r31 = D11 * D2[19]; r32 = D12 * D2[20]; r33 = D13 * D2[21]
-        r34 = D14 * D2[22]; r35 = D15 * D2[23]; r36 = D16 * D2[24]
-        r37 = D17 * D2[25]; r38 = D18 * D2[26]; r39 = D19 * D2[27]
-        r312 = r31 + r32; r334 = r33 + r34; r356 = r35 + r36; r378 = r37 + r38
-        r31234 = r312 + r334; r35678 = r356 + r378; r312345678 = r31234 + r35678
-        r3 = r312345678 + r39
-        r41 = D11 * D2[28]; r42 = D12 * D2[29]; r43 = D13 * D2[30]
-        r44 = D14 * D2[31]; r45 = D15 * D2[32]; r46 = D16 * D2[33]
-        r47 = D17 * D2[34]; r48 = D18 * D2[35]; r49 = D19 * D2[36]
-        r412 = r41 + r42; r434 = r43 + r44; r456 = r45 + r46; r478 = r47 + r48
-        r41234 = r412 + r434; r45678 = r456 + r478; r412345678 = r41234 + r45678
-        r4 = r412345678 + r49
-        r51 = D11 * D2[37]; r52 = D12 * D2[38]; r53 = D13 * D2[39]
-        r54 = D14 * D2[40]; r55 = D15 * D2[41]; r56 = D16 * D2[42]
-        r57 = D17 * D2[43]; r58 = D18 * D2[44]; r59 = D19 * D2[45]
-        r512 = r51 + r52; r534 = r53 + r54; r556 = r55 + r56; r578 = r57 + r58
-        r51234 = r512 + r534; r55678 = r556 + r578; r512345678 = r51234 + r55678
-        r5 = r512345678 + r59
-        r61 = D11 * D2[46]; r62 = D12 * D2[47]; r63 = D13 * D2[48]
-        r64 = D14 * D2[49]; r65 = D15 * D2[50]; r66 = D16 * D2[51]
-        r67 = D17 * D2[52]; r68 = D18 * D2[53]; r69 = D19 * D2[54]
-        r612 = r61 + r62; r634 = r63 + r64; r656 = r65 + r66; r678 = r67 + r68
-        r61234 = r612 + r634; r65678 = r656 + r678; r612345678 = r61234 + r65678
-        r6 = r612345678 + r69
-        r71 = D11 * D2[55]; r72 = D12 * D2[56]; r73 = D13 * D2[57]
-        r74 = D14 * D2[58]; r75 = D15 * D2[59]; r76 = D16 * D2[60]
-        r77 = D17 * D2[61]; r78 = D18 * D2[62]; r79 = D19 * D2[63]
-        r712 = r71 + r72; r734 = r73 + r74; r756 = r75 + r76; r778 = r77 + r78
-        r71234 = r712 + r734; r75678 = r756 + r778; r712345678 = r71234 + r75678
-        r7 = r712345678 + r79
-        r81 = D11 * D2[64]; r82 = D12 * D2[65]; r83 = D13 * D2[66]
-        r84 = D14 * D2[67]; r85 = D15 * D2[68]; r86 = D16 * D2[69]
-        r87 = D17 * D2[70]; r88 = D18 * D2[71]; r89 = D19 * D2[72]
-        r812 = r81 + r82; r834 = r83 + r84; r856 = r85 + r86; r878 = r87 + r88
-        r81234 = r812 + r834; r85678 = r856 + r878; r812345678 = r81234 + r85678
-        r8 = r812345678 + r89
-        r91 = D11 * D2[73]; r92 = D12 * D2[74]; r93 = D13 * D2[75]
-        r94 = D14 * D2[76]; r95 = D15 * D2[77]; r96 = D16 * D2[78]
-        r97 = D17 * D2[79]; r98 = D18 * D2[80]; r99 = D19 * D2[81]
-        r912 = r91 + r92; r934 = r93 + r94; r956 = r95 + r96; r978 = r97 + r98
-        r91234 = r912 + r934; r95678 = r956 + r978; r912345678 = r91234 + r95678
-        r9 = r912345678 + r99
+        r1 = fma(D19, D2[9],  fma(D18, D2[8],  fma(D17, D2[7],  fma(D16, D2[6],  fma(D15, D2[5],  fma(D14, D2[4],  fma(D13, D2[3],  fma(D12, D2[2],  D11 * D2[1] ))))))))
+        r2 = fma(D19, D2[18], fma(D18, D2[17], fma(D17, D2[16], fma(D16, D2[15], fma(D15, D2[14], fma(D14, D2[13], fma(D13, D2[12], fma(D12, D2[11], D11 * D2[10]))))))))
+        r3 = fma(D19, D2[27], fma(D18, D2[26], fma(D17, D2[25], fma(D16, D2[24], fma(D15, D2[23], fma(D14, D2[22], fma(D13, D2[21], fma(D12, D2[20], D11 * D2[19]))))))))
+        r4 = fma(D19, D2[36], fma(D18, D2[35], fma(D17, D2[34], fma(D16, D2[33], fma(D15, D2[32], fma(D14, D2[31], fma(D13, D2[30], fma(D12, D2[29], D11 * D2[28]))))))))
+        r5 = fma(D19, D2[45], fma(D18, D2[44], fma(D17, D2[43], fma(D16, D2[42], fma(D15, D2[41], fma(D14, D2[40], fma(D13, D2[39], fma(D12, D2[38], D11 * D2[37]))))))))
+        r6 = fma(D19, D2[54], fma(D18, D2[53], fma(D17, D2[52], fma(D16, D2[51], fma(D15, D2[50], fma(D14, D2[49], fma(D13, D2[48], fma(D12, D2[47], D11 * D2[46]))))))))
+        r7 = fma(D19, D2[63], fma(D18, D2[62], fma(D17, D2[61], fma(D16, D2[60], fma(D15, D2[59], fma(D14, D2[58], fma(D13, D2[57], fma(D12, D2[56], D11 * D2[55]))))))))
+        r8 = fma(D19, D2[72], fma(D18, D2[71], fma(D17, D2[70], fma(D16, D2[69], fma(D15, D2[68], fma(D14, D2[67], fma(D13, D2[66], fma(D12, D2[65], D11 * D2[64]))))))))
+        r9 = fma(D19, D2[81], fma(D18, D2[80], fma(D17, D2[79], fma(D16, D2[78], fma(D15, D2[77], fma(D14, D2[76], fma(D13, D2[75], fma(D12, D2[74], D11 * D2[73]))))))))
         return Tensor{4, 3}((r1, r2, r3, r4, r5, r6, r7, r8, r9))
     end
 end

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -2,7 +2,7 @@
 module ST # SIMDTensors
 
 using Tensors
-using Tensors: get_data
+using Tensors: get_data, AllTensors, n_components, get_base
 using Compat
 
 import SIMD
@@ -12,6 +12,8 @@ const SIMDTypes = Union{Bool,
                         Int8, Int16, Int32, Int32, Int128,
                         UInt8, UInt16, UInt32, UInt32, UInt128,
                         Float16, Float32, Float64}
+
+@compat const AllSIMDTensors{dim, T <: SIMDTypes} = AllTensors{dim, T}
 
 # SIMD sizes accepted by LLVM between 1 and 100
 const SIMD_CHUNKS = (1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 16, 17, 18, 20, 24, 32, 33, 34, 36, 40, 48, 64, 65, 66, 68, 72, 80, 96)
@@ -530,45 +532,236 @@ end
     end
 end
 
-@inline function +{T <: SIMDTypes}(S1::Tensor{2, 3, T}, S2::Tensor{2, 3, T})
+# +
+@generated function add{TT <: AllSIMDTensors}(S1::TT, S2::TT)
+    TensorType = get_base(S1)
+    T = eltype(TT)
+    N = n_components(TensorType)
+    D1 = :(D1 = SVec{$N, $T}(get_data(S1)))
+    D2 = :(D2 = SVec{$N, $T}(get_data(S2)))
+    r = :(r = D1 + D2)
+    expr = Expr(:tuple, [:(r[$i]) for i in 1:N]...)
+    return quote
+        $(Expr(:meta, :inline))
+        @inbounds begin
+            $D1
+            $D2
+            $r
+            return $TensorType($expr)
+        end
+    end
+end
+@inline function add{T <: SIMDTypes}(S1::Tensor{4, 3, T}, S2::Tensor{4, 3, T})
     @inbounds begin
-        D1 = SVec{9, T}(get_data(S1))
-        D2 = SVec{9, T}(get_data(S2))
-
-        r = D1 + D2
-
-        return Tensor{2, 3}((r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]))
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+        D180 = SVec{80, T}((D1[1],  D1[2],  D1[3],  D1[4],  D1[5],  D1[6],  D1[7],  D1[8],  D1[9],
+                            D1[10], D1[11], D1[12], D1[13], D1[14], D1[15], D1[16], D1[17], D1[18],
+                            D1[19], D1[20], D1[21], D1[22], D1[23], D1[24], D1[25], D1[26], D1[27],
+                            D1[28], D1[29], D1[30], D1[31], D1[32], D1[33], D1[34], D1[35], D1[36],
+                            D1[37], D1[38], D1[39], D1[40], D1[41], D1[42], D1[43], D1[44], D1[45],
+                            D1[46], D1[47], D1[48], D1[49], D1[50], D1[51], D1[52], D1[53], D1[54],
+                            D1[55], D1[56], D1[57], D1[58], D1[59], D1[60], D1[61], D1[62], D1[63],
+                            D1[64], D1[65], D1[66], D1[67], D1[68], D1[69], D1[70], D1[71], D1[72],
+                            D1[73], D1[74], D1[75], D1[76], D1[77], D1[78], D1[79], D1[80]))
+        D280 = SVec{80, T}((D2[1],  D2[2],  D2[3],  D2[4],  D2[5],  D2[6],  D2[7],  D2[8],  D2[9],
+                            D2[10], D2[11], D2[12], D2[13], D2[14], D2[15], D2[16], D2[17], D2[18],
+                            D2[19], D2[20], D2[21], D2[22], D2[23], D2[24], D2[25], D2[26], D2[27],
+                            D2[28], D2[29], D2[30], D2[31], D2[32], D2[33], D2[34], D2[35], D2[36],
+                            D2[37], D2[38], D2[39], D2[40], D2[41], D2[42], D2[43], D2[44], D2[45],
+                            D2[46], D2[47], D2[48], D2[49], D2[50], D2[51], D2[52], D2[53], D2[54],
+                            D2[55], D2[56], D2[57], D2[58], D2[59], D2[60], D2[61], D2[62], D2[63],
+                            D2[64], D2[65], D2[66], D2[67], D2[68], D2[69], D2[70], D2[71], D2[72],
+                            D2[73], D2[74], D2[75], D2[76], D2[77], D2[78], D2[79], D2[80]))
+        r = D180 + D280
+        r81 = D1[81] + D2[81]
+        return Tensor{4, 3}((r[1],  r[2],  r[3],  r[4],  r[5],  r[6],  r[7],  r[8],  r[9],
+                             r[10], r[11], r[12], r[13], r[14], r[15], r[16], r[17], r[18],
+                             r[19], r[20], r[21], r[22], r[23], r[24], r[25], r[26], r[27],
+                             r[28], r[29], r[30], r[31], r[32], r[33], r[34], r[35], r[36],
+                             r[37], r[38], r[39], r[40], r[41], r[42], r[43], r[44], r[45],
+                             r[46], r[47], r[48], r[49], r[50], r[51], r[52], r[53], r[54],
+                             r[55], r[56], r[57], r[58], r[59], r[60], r[61], r[62], r[63],
+                             r[64], r[65], r[66], r[67], r[68], r[69], r[70], r[71], r[72],
+                             r[73], r[74], r[75], r[76], r[77], r[78], r[79], r[80], r81))
     end
 end
 
-@inline function -{T <: SIMDTypes}(S1::Tensor{2, 3, T}, S2::Tensor{2, 3, T})
+# -
+@generated function sub{TT <: AllSIMDTensors}(S1::TT, S2::TT)
+    TensorType = get_base(S1)
+    T = eltype(TT)
+    N = n_components(TensorType)
+    D1 = :(D1 = SVec{$N, $T}(get_data(S1)))
+    D2 = :(D2 = SVec{$N, $T}(get_data(S2)))
+    r = :(r = D1 - D2)
+    expr = Expr(:tuple, [:(r[$i]) for i in 1:N]...)
+    return quote
+        $(Expr(:meta, :inline))
+        @inbounds begin
+            $D1
+            $D2
+            $r
+            return $TensorType($expr)
+        end
+    end
+end
+@inline function sub{T <: SIMDTypes}(S1::Tensor{4, 3, T}, S2::Tensor{4, 3, T})
     @inbounds begin
-        D1 = SVec{9, T}(get_data(S1))
-        D2 = SVec{9, T}(get_data(S2))
-
-        r = D1 - D2
-
-        return Tensor{2, 3}((r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]))
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+        D180 = SVec{80, T}((D1[1],  D1[2],  D1[3],  D1[4],  D1[5],  D1[6],  D1[7],  D1[8],  D1[9],
+                            D1[10], D1[11], D1[12], D1[13], D1[14], D1[15], D1[16], D1[17], D1[18],
+                            D1[19], D1[20], D1[21], D1[22], D1[23], D1[24], D1[25], D1[26], D1[27],
+                            D1[28], D1[29], D1[30], D1[31], D1[32], D1[33], D1[34], D1[35], D1[36],
+                            D1[37], D1[38], D1[39], D1[40], D1[41], D1[42], D1[43], D1[44], D1[45],
+                            D1[46], D1[47], D1[48], D1[49], D1[50], D1[51], D1[52], D1[53], D1[54],
+                            D1[55], D1[56], D1[57], D1[58], D1[59], D1[60], D1[61], D1[62], D1[63],
+                            D1[64], D1[65], D1[66], D1[67], D1[68], D1[69], D1[70], D1[71], D1[72],
+                            D1[73], D1[74], D1[75], D1[76], D1[77], D1[78], D1[79], D1[80]))
+        D280 = SVec{80, T}((D2[1],  D2[2],  D2[3],  D2[4],  D2[5],  D2[6],  D2[7],  D2[8],  D2[9],
+                            D2[10], D2[11], D2[12], D2[13], D2[14], D2[15], D2[16], D2[17], D2[18],
+                            D2[19], D2[20], D2[21], D2[22], D2[23], D2[24], D2[25], D2[26], D2[27],
+                            D2[28], D2[29], D2[30], D2[31], D2[32], D2[33], D2[34], D2[35], D2[36],
+                            D2[37], D2[38], D2[39], D2[40], D2[41], D2[42], D2[43], D2[44], D2[45],
+                            D2[46], D2[47], D2[48], D2[49], D2[50], D2[51], D2[52], D2[53], D2[54],
+                            D2[55], D2[56], D2[57], D2[58], D2[59], D2[60], D2[61], D2[62], D2[63],
+                            D2[64], D2[65], D2[66], D2[67], D2[68], D2[69], D2[70], D2[71], D2[72],
+                            D2[73], D2[74], D2[75], D2[76], D2[77], D2[78], D2[79], D2[80]))
+        r = D180 - D280
+        r81 = D1[81] - D2[81]
+        return Tensor{4, 3}((r[1],  r[2],  r[3],  r[4],  r[5],  r[6],  r[7],  r[8],  r[9],
+                             r[10], r[11], r[12], r[13], r[14], r[15], r[16], r[17], r[18],
+                             r[19], r[20], r[21], r[22], r[23], r[24], r[25], r[26], r[27],
+                             r[28], r[29], r[30], r[31], r[32], r[33], r[34], r[35], r[36],
+                             r[37], r[38], r[39], r[40], r[41], r[42], r[43], r[44], r[45],
+                             r[46], r[47], r[48], r[49], r[50], r[51], r[52], r[53], r[54],
+                             r[55], r[56], r[57], r[58], r[59], r[60], r[61], r[62], r[63],
+                             r[64], r[65], r[66], r[67], r[68], r[69], r[70], r[71], r[72],
+                             r[73], r[74], r[75], r[76], r[77], r[78], r[79], r[80], r81))
     end
 end
 
-@inline function mul{T <: SIMDTypes}(n::T, S2::Tensor{2, 3, T})
-    @inbounds begin
-        D2 = SVec{9, T}(get_data(S2))
-
-        r = n * D2
-
-        return Tensor{2, 3}((r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]))
+# *, /
+@generated function mul{T <: SIMDTypes, TT <: AllSIMDTensors}(n::T, S::TT)
+    TensorType = get_base(S)
+    N = n_components(TensorType)
+    D = :(D = SVec{$N, T}(get_data(S)))
+    r = :(r = n * D)
+    expr = Expr(:tuple, [:(r[$i]) for i in 1:N]...)
+    return quote
+        $(Expr(:meta, :inline))
+        @inbounds begin
+            $D
+            $r
+            return $TensorType($expr)
+        end
+    end
+end
+@generated function mul{TT <: AllSIMDTensors, T <: SIMDTypes, }(S::TT, n::T)
+    TensorType = get_base(S)
+    N = n_components(TensorType)
+    D = :(D = SVec{$N, T}(get_data(S)))
+    r = :(r = D * n)
+    expr = Expr(:tuple, [:(r[$i]) for i in 1:N]...)
+    return quote
+        $(Expr(:meta, :inline))
+        @inbounds begin
+            $D
+            $r
+            return $TensorType($expr)
+        end
+    end
+end
+@generated function div{TT <: AllSIMDTensors, T <: SIMDTypes, }(S::TT, n::T)
+    TensorType = get_base(S)
+    N = n_components(TensorType)
+    D = :(D = SVec{$N, T}(get_data(S)))
+    r = :(r = D / n)
+    expr = Expr(:tuple, [:(r[$i]) for i in 1:N]...)
+    return quote
+        $(Expr(:meta, :inline))
+        @inbounds begin
+            $D
+            $r
+            return $TensorType($expr)
+        end
     end
 end
 
-@inline function mul{T <: SIMDTypes}(S1::Tensor{2, 3, T}, n::T)
+@inline function mul{T <: SIMDTypes}(n::T, S::Tensor{4, 3, T})
     @inbounds begin
-        D1 = SVec{9, T}(get_data(S1))
-
-        r = D1 * n
-
-        return Tensor{2, 3}((r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]))
+        D = get_data(S)
+        D80 = SVec{80, T}((D[1],  D[2],  D[3],  D[4],  D[5],  D[6],  D[7],  D[8],  D[9],
+                           D[10], D[11], D[12], D[13], D[14], D[15], D[16], D[17], D[18],
+                           D[19], D[20], D[21], D[22], D[23], D[24], D[25], D[26], D[27],
+                           D[28], D[29], D[30], D[31], D[32], D[33], D[34], D[35], D[36],
+                           D[37], D[38], D[39], D[40], D[41], D[42], D[43], D[44], D[45],
+                           D[46], D[47], D[48], D[49], D[50], D[51], D[52], D[53], D[54],
+                           D[55], D[56], D[57], D[58], D[59], D[60], D[61], D[62], D[63],
+                           D[64], D[65], D[66], D[67], D[68], D[69], D[70], D[71], D[72],
+                           D[73], D[74], D[75], D[76], D[77], D[78], D[79], D[80]))
+        r   = n * D80
+        r81 = n * D[81]
+        return Tensor{4, 3}((r[1],  r[2],  r[3],  r[4],  r[5],  r[6],  r[7],  r[8],  r[9],
+                             r[10], r[11], r[12], r[13], r[14], r[15], r[16], r[17], r[18],
+                             r[19], r[20], r[21], r[22], r[23], r[24], r[25], r[26], r[27],
+                             r[28], r[29], r[30], r[31], r[32], r[33], r[34], r[35], r[36],
+                             r[37], r[38], r[39], r[40], r[41], r[42], r[43], r[44], r[45],
+                             r[46], r[47], r[48], r[49], r[50], r[51], r[52], r[53], r[54],
+                             r[55], r[56], r[57], r[58], r[59], r[60], r[61], r[62], r[63],
+                             r[64], r[65], r[66], r[67], r[68], r[69], r[70], r[71], r[72],
+                             r[73], r[74], r[75], r[76], r[77], r[78], r[79], r[80], r81))
+    end
+end
+@inline function mul{T <: SIMDTypes}(S::Tensor{4, 3, T}, n::T)
+    @inbounds begin
+        D = get_data(S)
+        D80 = SVec{80, T}((D[1],  D[2],  D[3],  D[4],  D[5],  D[6],  D[7],  D[8],  D[9],
+                           D[10], D[11], D[12], D[13], D[14], D[15], D[16], D[17], D[18],
+                           D[19], D[20], D[21], D[22], D[23], D[24], D[25], D[26], D[27],
+                           D[28], D[29], D[30], D[31], D[32], D[33], D[34], D[35], D[36],
+                           D[37], D[38], D[39], D[40], D[41], D[42], D[43], D[44], D[45],
+                           D[46], D[47], D[48], D[49], D[50], D[51], D[52], D[53], D[54],
+                           D[55], D[56], D[57], D[58], D[59], D[60], D[61], D[62], D[63],
+                           D[64], D[65], D[66], D[67], D[68], D[69], D[70], D[71], D[72],
+                           D[73], D[74], D[75], D[76], D[77], D[78], D[79], D[80]))
+        r   = D80 * n
+        r81 = D[81] * n
+        return Tensor{4, 3}((r[1],  r[2],  r[3],  r[4],  r[5],  r[6],  r[7],  r[8],  r[9],
+                             r[10], r[11], r[12], r[13], r[14], r[15], r[16], r[17], r[18],
+                             r[19], r[20], r[21], r[22], r[23], r[24], r[25], r[26], r[27],
+                             r[28], r[29], r[30], r[31], r[32], r[33], r[34], r[35], r[36],
+                             r[37], r[38], r[39], r[40], r[41], r[42], r[43], r[44], r[45],
+                             r[46], r[47], r[48], r[49], r[50], r[51], r[52], r[53], r[54],
+                             r[55], r[56], r[57], r[58], r[59], r[60], r[61], r[62], r[63],
+                             r[64], r[65], r[66], r[67], r[68], r[69], r[70], r[71], r[72],
+                             r[73], r[74], r[75], r[76], r[77], r[78], r[79], r[80], r81))
+    end
+end
+@inline function div{T <: SIMDTypes}(S::Tensor{4, 3, T}, n::T)
+    @inbounds begin
+        D = get_data(S)
+        D80 = SVec{80, T}((D[1],  D[2],  D[3],  D[4],  D[5],  D[6],  D[7],  D[8],  D[9],
+                           D[10], D[11], D[12], D[13], D[14], D[15], D[16], D[17], D[18],
+                           D[19], D[20], D[21], D[22], D[23], D[24], D[25], D[26], D[27],
+                           D[28], D[29], D[30], D[31], D[32], D[33], D[34], D[35], D[36],
+                           D[37], D[38], D[39], D[40], D[41], D[42], D[43], D[44], D[45],
+                           D[46], D[47], D[48], D[49], D[50], D[51], D[52], D[53], D[54],
+                           D[55], D[56], D[57], D[58], D[59], D[60], D[61], D[62], D[63],
+                           D[64], D[65], D[66], D[67], D[68], D[69], D[70], D[71], D[72],
+                           D[73], D[74], D[75], D[76], D[77], D[78], D[79], D[80]))
+        r   = D80 / n
+        r81 = D[81] / n
+        return Tensor{4, 3}((r[1],  r[2],  r[3],  r[4],  r[5],  r[6],  r[7],  r[8],  r[9],
+                             r[10], r[11], r[12], r[13], r[14], r[15], r[16], r[17], r[18],
+                             r[19], r[20], r[21], r[22], r[23], r[24], r[25], r[26], r[27],
+                             r[28], r[29], r[30], r[31], r[32], r[33], r[34], r[35], r[36],
+                             r[37], r[38], r[39], r[40], r[41], r[42], r[43], r[44], r[45],
+                             r[46], r[47], r[48], r[49], r[50], r[51], r[52], r[53], r[54],
+                             r[55], r[56], r[57], r[58], r[59], r[60], r[61], r[62], r[63],
+                             r[64], r[65], r[66], r[67], r[68], r[69], r[70], r[71], r[72],
+                             r[73], r[74], r[75], r[76], r[77], r[78], r[79], r[80], r81))
     end
 end
 

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -154,7 +154,7 @@ end
         $(Expr(:meta, :inline))
         @inbounds begin
             D = get_data(S); SV = tosimd(D)
-            r = n * D
+            r = n * SV
             return $TensorType(r)
         end
     end

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -462,6 +462,15 @@ end
         return Tensor{4, 3}((r1, r2, r3, r4, r5, r6, r7, r8, r9))
     end
 end
+@inline function Tensors.otimes{T <: SIMDTypes}(S1::SymmetricTensor{2, 2, T}, S2::SymmetricTensor{2, 2, T})
+    @inbounds begin
+        D1 = get_data(S1)
+        D2 = get_data(S2)
+        D11 = SVec{3, T}(D1)
+        r1 = D11 * D2[1]; r2 = D11 * D2[2]; r3 = D11 * D2[3]
+        return SymmetricTensor{4, 2}((r1, r2, r3))
+    end
+end
 @inline function Tensors.otimes{T <: SIMDTypes}(S1::SymmetricTensor{2, 3, T}, S2::SymmetricTensor{2, 3, T})
     @inbounds begin
         D1 = get_data(S1)
@@ -477,7 +486,7 @@ end
 # (6): norm #
 #############
 # order 1 and order 2 norms rely on dot and dcontract respectively
-@inline function Base.norm{dim, T <: SIMDTypes, N}(S::Tensor{4, dim, T, N})
+@inline function Base.norm{T <: SIMDTypes, N}(S::Tensor{4, 2, T, N})
     @inbounds begin
         D = SVec{N, T}(get_data(S))
         DD = D * D

--- a/test/F64.jl
+++ b/test/F64.jl
@@ -28,5 +28,5 @@ Base.promote_type(::Type{Float64}, ::Type{F64}) = Float64 # for vecnorm
 Base.promote{T <: Number}(a::F64, b::T) = a, F64(b)
 Base.promote{T <: Number}(a::T, b::F64) = F64(a), b
 Base.convert(::Type{F64}, a::F64) = a
-Base.convert{T <: Number}(::Type{T}, a::F64) = T(a.x)
+Base.convert(::Type{Float64}, a::F64) = a.x
 Base.convert{T <: Number}(::Type{F64}, a::T) = F64(a)

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -40,6 +40,7 @@ for dim in 1:3
     @test Δ(Ψ, C) ⊡ b ≈ Δ(Ψ, C2) ⊡ b
 
     for T in (Float32, Float64)
+        srand(1234) # needed for getting "good" tensors for calculating det and friends
         A = rand(Tensor{2, dim, T})
         B = rand(Tensor{2, dim, T})
         A_sym = rand(SymmetricTensor{2, dim, T})


### PR DESCRIPTION
This forces SIMD operations to be used even if julia is run with `-O2`.

TODO:
- [x] Basic operations
- [x] Dot products
- [x] ~Combined products with `Tensor`/`SymmetricTensor`~ postpone this to another PR
- [x] Tests
- [x] Fix dispatch
- [ ] Benchmarks
- [x] Clean up