### PR TITLE
Introduce a dummy type F64 to test with

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -108,10 +108,11 @@ end
 @generated function Base.diagm{T <: SecondOrderTensor}(S::Type{T}, v::Union{AbstractVector, Tuple})
     TensorType = get_base(get_type(S))
     ET = eltype(get_type(S)) == Any ? eltype(v) : eltype(get_type(S)) # lol
-    f = (i,j) -> i == j ? :($ET(v[$i])) : :($(zero(ET)))
+    f = (i,j) -> i == j ? :($ET(v[$i])) : :(o)
     exp = tensor_create(TensorType, f)
     return quote
         $(Expr(:meta, :inline))
+        o = zero($ET)
         @inbounds return $TensorType($exp)
     end
 end

--- a/test/F64.jl
+++ b/test/F64.jl
@@ -1,0 +1,31 @@
+# dummy type wrapping a Float64 used in tests
+immutable F64 <: AbstractFloat
+    x::Float64
+end
+
+# operations
+for op in (:+, :-)
+    @eval Base.$op(a::F64) = F64($op(a.x))
+end
+for op in (:+, :-, :*, :/)
+    @eval Base.$op(a::F64, b::F64) = F64($op(a.x, b.x))
+end
+for op in(:zero, :one)
+    @eval Base.$op(::Type{F64}) = F64($op(Float64))
+end
+Base.rand(rng::AbstractRNG, F64) = F64(rand())
+Base.sqrt(a::F64) = F64(sqrt(a.x))
+
+# comparison
+Base.isapprox(a::F64, b::F64) = isapprox(a.x, b.x)
+Base.:<(a::F64, b::F64) = a.x < b.x
+Base.:<=(a::F64, b::F64) = a.x <= b.x
+Base.eps(::Type{F64}) = eps(Float64)
+
+# promotion
+Base.promote_type(::Type{Float32}, ::Type{F64}) = Float64 # for eig
+Base.promote{T <: Number}(a::F64, b::T) = a, F64(b)
+Base.promote{T <: Number}(a::T, b::F64) = F64(a), b
+Base.convert(::Type{F64}, a::F64) = a
+Base.convert{T <: Number}(::Type{T}, a::F64) = T(a.x)
+Base.convert{T <: Number}(::Type{F64}, a::T) = F64(a)

--- a/test/F64.jl
+++ b/test/F64.jl
@@ -24,6 +24,7 @@ Base.eps(::Type{F64}) = eps(Float64)
 
 # promotion
 Base.promote_type(::Type{Float32}, ::Type{F64}) = Float64 # for eig
+Base.promote_type(::Type{Float64}, ::Type{F64}) = Float64 # for vecnorm
 Base.promote{T <: Number}(a::F64, b::T) = a, F64(b)
 Base.promote{T <: Number}(a::T, b::F64) = F64(a), b
 Base.convert(::Type{F64}, a::F64) = a

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Tensors
 using Base.Test
 
+include("F64.jl")
 include("test_misc.jl")
 include("test_ops.jl")
 include("test_ad.jl")

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -1,5 +1,5 @@
 @testset "basic constructors: rand, zero, ones" begin
-for T in (Float32, Float64), dim in (1,2,3), order in (1,2,4)
+for T in (Float32, Float64, F64), dim in (1,2,3), order in (1,2,4)
     for op in (:rand, :zero, :ones)
         # Tensor, SymmetricTensor
         for TensorType in (Tensor, SymmetricTensor)
@@ -53,7 +53,7 @@ end
 end # of testset
 
 @testset "diagm, one" begin
-for T in (Float32, Float64), dim in (1,2,3)
+for T in (Float32, Float64, F64), dim in (1,2,3)
     # diagm
     v = rand(T, dim)
     vt = (v...)
@@ -113,7 +113,7 @@ end
 end # of testset
 
 @testset "base vectors" begin
-for T in (Float32, Float64), dim in (1,2,3)
+for T in (Float32, Float64, F64), dim in (1,2,3)
     eᵢ_func(i) = Tensor{1, dim, T}(j->j==i ? one(T) : zero(T))
 
     a = rand(Vec{dim, T})
@@ -162,7 +162,7 @@ end
 end # of testset
 
 @testset "create with a function" begin
-for T in (Float32, Float64)
+for T in (Float32, Float64, F64)
     for dim in (1,2,3)
         fi = (i) -> cos(i)
         fij = (i,j) -> cos(i) + sin(j)
@@ -236,7 +236,7 @@ end
 end # of testset
 
 @testset "indexing" begin
-for T in (Float32, Float64), dim in (1,2,3), order in (1,2,4)
+for T in (Float32, Float64, F64), dim in (1,2,3), order in (1,2,4)
     if order == 1
         data = rand(T, dim)
         vec = Tensor{order, dim, T}(data)
@@ -295,7 +295,7 @@ end
 end # of testset
 
 @testset "norm, trace, det, inv, eig" begin
-for T in (Float32, Float64), dim in (1,2,3)
+for T in (Float32, Float64, F64), dim in (1,2,3)
     # norm
     for order in (1,2,4)
         t = rand(Tensor{order, dim, T})
@@ -346,7 +346,7 @@ end # of testset
 
 # https://en.wikiversity.org/wiki/Continuum_mechanics/Tensor_algebra_identities
 @testset "tensor identities" begin
-for T in (Float32, Float64)
+for T in (Float32, Float64, F64)
     for dim in (1,2,3)
         # Identities with second order and first order
         A = rand(Tensor{2, dim, T})
@@ -386,7 +386,7 @@ for T in (Float32, Float64)
     end
 end
 
-for T in (Float32, Float64)
+for T in (Float32, Float64, F64)
     for dim in (1,2,3)
         # Identities with identity tensor
         II = one(Tensor{4, dim, T})

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -5,8 +5,8 @@ function _permutedims{dim}(S::FourthOrderTensor{dim}, idx::NTuple{4,Int})
     return Tensor{4,dim}(f)
 end
 
-@testset "tensor operations" begin;
-for T in (Float32, Float64), dim in (1,2,3)
+@testset "tensor operations" begin
+for T in (Float32, Float64, F64), dim in (1,2,3)
 AA = rand(Tensor{4, dim, T})
 BB = rand(Tensor{4, dim, T})
 A = rand(Tensor{2, dim, T})


### PR DESCRIPTION
This allows the "normal" methods to still be tested after the simd-forcing methods is introduced.