### PR TITLE
add summary of time for tests

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 ForwardDiff
 Documenter
+TimerOutputs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,24 @@
 using Tensors
 using Base.Test
+using TimerOutputs
+
+macro testsection(args...)
+    name = esc(args[1])
+    return quote
+        @timeit $name begin
+            @testset($(map(esc, args)...))
+        end
+    end
+end
+
+reset_timer!()
 
 include("F64.jl")
 include("test_misc.jl")
 include("test_ops.jl")
 include("test_ad.jl")
+
+print_timer()
 
 # Build the docs
 include("../docs/make.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ include("test_ops.jl")
 include("test_ad.jl")
 
 print_timer()
+println()
 
 # Build the docs
 include("../docs/make.jl")

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -49,51 +49,58 @@ S(C) = S(C, μ, Kb)
             II_sym = one(SymmetricTensor{4, dim, T})
 
             # Gradient of scalars
-            @test ∇(norm, v) ≈ ∇(norm, v, :all)[1] ≈ v / norm(v)
-            @test ∇(norm, v, :all)[2] ≈ norm(v)
-            @test ∇(norm, A) ≈ ∇(norm, A, :all)[1] ≈ A / norm(A)
-            @test ∇(norm, A, :all)[2] ≈ norm(A)
-            @test ∇(norm, A_sym) ≈ ∇(norm, A_sym, :all)[1] ≈ A_sym / norm(A_sym)
-            @test ∇(norm, A_sym, :all)[2] ≈ norm(A_sym)
-            @test ∇(v -> 3*v, v) ≈ ∇(v -> 3*v, v, :all)[1] ≈ diagm(Tensor{2, dim}, 3.0)
-            @test ∇(v -> 3*v, v, :all)[2] ≈ 3*v
-            # https://en.wikipedia.org/wiki/Tensor_derivative_(continuum_mechanics)#Derivatives_of_the_invariants_of_a_second-order_tensor
-            I1, DI1 = A -> trace(A), A -> one(A)
-            I2, DI2 = A -> 1/2 * (trace(A)^2 - trace(A⋅A)), A -> I1(A) * one(A) - A'
-            I3, DI3 = A -> det(A), A -> det(A) * inv(A)'
+            @testsection "scalar grad" begin
+                @test ∇(norm, v) ≈ ∇(norm, v, :all)[1] ≈ v / norm(v)
+                @test ∇(norm, v, :all)[2] ≈ norm(v)
+                @test ∇(norm, A) ≈ ∇(norm, A, :all)[1] ≈ A / norm(A)
+                @test ∇(norm, A, :all)[2] ≈ norm(A)
+                @test ∇(norm, A_sym) ≈ ∇(norm, A_sym, :all)[1] ≈ A_sym / norm(A_sym)
+                @test ∇(norm, A_sym, :all)[2] ≈ norm(A_sym)
+                @test ∇(v -> 3*v, v) ≈ ∇(v -> 3*v, v, :all)[1] ≈ diagm(Tensor{2, dim}, 3.0)
+                @test ∇(v -> 3*v, v, :all)[2] ≈ 3*v
+            end
 
-            @test ∇(I1, A) ≈ ∇(I1, A, :all)[1] ≈ DI1(A)
-            @test ∇(I1, A, :all)[2] ≈ I1(A)
-            @test ∇(I2, A) ≈ ∇(I2, A, :all)[1] ≈ DI2(A)
-            @test ∇(I2, A, :all)[2] ≈ I2(A)
-            @test ∇(I3, A) ≈ ∇(I3, A, :all)[1] ≈ DI3(A)
-            @test ∇(I3, A, :all)[2] ≈ I3(A)
-            @test ∇(I1, A_sym) ≈ ∇(I1, A_sym, :all)[1] ≈ DI1(A_sym)
-            @test ∇(I1, A_sym, :all)[2] ≈ I1(A_sym)
-            @test ∇(I2, A_sym) ≈ ∇(I2, A_sym, :all)[1] ≈ DI2(A_sym)
-            @test ∇(I2, A_sym, :all)[2] ≈ I2(A_sym)
-            @test ∇(I3, A_sym) ≈ ∇(I3, A_sym, :all)[1] ≈ DI3(A_sym)
-            @test ∇(I3, A_sym, :all)[2] ≈ I3(A_sym)
-
+            @testsection "2nd tensor grad" begin
             # Gradient of second order tensors
-            @test ∇(identity, A) ≈ ∇(identity, A, :all)[1] ≈ II
-            @test ∇(identity, A, :all)[2] ≈ A
-            @test ∇(identity, A_sym) ≈ ∇(identity, A_sym, :all)[1] ≈ II_sym
-            @test ∇(identity, A_sym, :all)[2] ≈ A_sym
-            @test ∇(transpose, A) ⊡ B ≈ ∇(transpose, A, :all)[1] ⊡ B ≈ B'
-            @test ∇(transpose, A, :all)[2] ≈ A'
-            @test ∇(transpose, A_sym) ⊡ B_sym ≈ ∇(transpose, A_sym, :all)[1] ⊡ B_sym ≈ B_sym'
-            @test ∇(transpose, A_sym, :all)[2] ≈ A_sym'
-            @test ∇(inv, A) ⊡ B ≈ ∇(inv, A, :all)[1] ⊡ B ≈ - inv(A) ⋅ B ⋅ inv(A)
-            @test ∇(inv, A, :all)[2] ≈ inv(A)
-            @test ∇(inv, A_sym) ⊡ B_sym ≈ ∇(inv, A_sym, :all)[1] ⊡ B_sym ≈ - inv(A_sym) ⋅ B_sym ⋅ inv(A_sym)
-            @test ∇(inv, A_sym, :all)[2] ≈ inv(A_sym)
+            # https://en.wikipedia.org/wiki/Tensor_derivative_(continuum_mechanics)#Derivatives_of_the_invariants_of_a_second-order_tensor
+                I1, DI1 = A -> trace(A), A -> one(A)
+                I2, DI2 = A -> 1/2 * (trace(A)^2 - trace(A⋅A)), A -> I1(A) * one(A) - A'
+                I3, DI3 = A -> det(A), A -> det(A) * inv(A)'
+
+                @test ∇(I1, A) ≈ ∇(I1, A, :all)[1] ≈ DI1(A)
+                @test ∇(I1, A, :all)[2] ≈ I1(A)
+                @test ∇(I2, A) ≈ ∇(I2, A, :all)[1] ≈ DI2(A)
+                @test ∇(I2, A, :all)[2] ≈ I2(A)
+                @test ∇(I3, A) ≈ ∇(I3, A, :all)[1] ≈ DI3(A)
+                @test ∇(I3, A, :all)[2] ≈ I3(A)
+                @test ∇(I1, A_sym) ≈ ∇(I1, A_sym, :all)[1] ≈ DI1(A_sym)
+                @test ∇(I1, A_sym, :all)[2] ≈ I1(A_sym)
+                @test ∇(I2, A_sym) ≈ ∇(I2, A_sym, :all)[1] ≈ DI2(A_sym)
+                @test ∇(I2, A_sym, :all)[2] ≈ I2(A_sym)
+                @test ∇(I3, A_sym) ≈ ∇(I3, A_sym, :all)[1] ≈ DI3(A_sym)
+                @test ∇(I3, A_sym, :all)[2] ≈ I3(A_sym)
+
+                @test ∇(identity, A) ≈ ∇(identity, A, :all)[1] ≈ II
+                @test ∇(identity, A, :all)[2] ≈ A
+                @test ∇(identity, A_sym) ≈ ∇(identity, A_sym, :all)[1] ≈ II_sym
+                @test ∇(identity, A_sym, :all)[2] ≈ A_sym
+                @test ∇(transpose, A) ⊡ B ≈ ∇(transpose, A, :all)[1] ⊡ B ≈ B'
+                @test ∇(transpose, A, :all)[2] ≈ A'
+                @test ∇(transpose, A_sym) ⊡ B_sym ≈ ∇(transpose, A_sym, :all)[1] ⊡ B_sym ≈ B_sym'
+                @test ∇(transpose, A_sym, :all)[2] ≈ A_sym'
+                @test ∇(inv, A) ⊡ B ≈ ∇(inv, A, :all)[1] ⊡ B ≈ - inv(A) ⋅ B ⋅ inv(A)
+                @test ∇(inv, A, :all)[2] ≈ inv(A)
+                @test ∇(inv, A_sym) ⊡ B_sym ≈ ∇(inv, A_sym, :all)[1] ⊡ B_sym ≈ - inv(A_sym) ⋅ B_sym ⋅ inv(A_sym)
+                @test ∇(inv, A_sym, :all)[2] ≈ inv(A_sym)
+            end
 
             # Hessians of scalars
-            @test Δ(norm, A) ≈ Δ(norm, A, :all)[1] ≈ reshape(ForwardDiff.hessian(x -> sqrt(sum(abs2, x)), A), (dim, dim, dim, dim))
-            @test Array(Δ(norm, A, :all)[2]) ≈ reshape(ForwardDiff.gradient(x -> sqrt(sum(abs2, x)), A), (dim, dim))
-            @test Δ(norm, A, :all)[3] ≈ norm(A)
-            end # loop T
+            @testsection "hessian" begin
+                @test Δ(norm, A) ≈ Δ(norm, A, :all)[1] ≈ reshape(ForwardDiff.hessian(x -> sqrt(sum(abs2, x)), A), (dim, dim, dim, dim))
+                @test Array(Δ(norm, A, :all)[2]) ≈ reshape(ForwardDiff.gradient(x -> sqrt(sum(abs2, x)), A), (dim, dim))
+                @test Δ(norm, A, :all)[3] ≈ norm(A)
+            end
+            end # loop T            
         end # testsection
     end # loop dim
 end # testsection

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -20,77 +20,80 @@ const Kb = 1.66e11;
 Ψ(C) = Ψ(C, μ, Kb)
 S(C) = S(C, μ, Kb)
 
-@testset "AD: dim = $dim" for dim in 1:3
+@testsection "AD" begin
+    for dim in 1:3
+        @testsection "dim $dim" begin
+        F = one(Tensor{2,dim}) + rand(Tensor{2,dim});
+        C = tdot(F);
+        C2 = F' ⋅ F;
 
-    F = one(Tensor{2,dim}) + rand(Tensor{2,dim});
-    C = tdot(F);
-    C2 = F' ⋅ F;
+        @test 2∇(Ψ, C) ≈ S(C)
+        @test 2∇(Ψ, C2) ≈ S(C2)
 
-    @test 2∇(Ψ, C) ≈ S(C)
-    @test 2∇(Ψ, C2) ≈ S(C2)
+        b = rand(SymmetricTensor{2, dim})
+        @test 2 * Δ(Ψ, C) ⊡ b ≈ ∇(S, C) ⊡ b
+        @test 2 * Δ(Ψ, C2) ⊡ b ≈ ∇(S, C2) ⊡ b
 
-    b = rand(SymmetricTensor{2, dim})
-    @test 2 * Δ(Ψ, C) ⊡ b ≈ ∇(S, C) ⊡ b
-    @test 2 * Δ(Ψ, C2) ⊡ b ≈ ∇(S, C2) ⊡ b
+        @test ∇(Ψ, C) ≈ ∇(Ψ, C2)
+        @test ∇(S, C) ⊡ b ≈ ∇(S, C2) ⊡ b
+        @test Δ(Ψ, C) ⊡ b ≈ Δ(Ψ, C2) ⊡ b
 
-    @test ∇(Ψ, C) ≈ ∇(Ψ, C2)
-    @test ∇(S, C) ⊡ b ≈ ∇(S, C2) ⊡ b
-    @test Δ(Ψ, C) ⊡ b ≈ Δ(Ψ, C2) ⊡ b
+        for T in (Float32, Float64)
+            srand(1234) # needed for getting "good" tensors for calculating det and friends
+            A = rand(Tensor{2, dim, T})
+            B = rand(Tensor{2, dim, T})
+            A_sym = rand(SymmetricTensor{2, dim, T})
+            B_sym = rand(SymmetricTensor{2, dim, T})
+            v = rand(Vec{dim, T})
+            II = one(Tensor{4, dim, T})
+            II_sym = one(SymmetricTensor{4, dim, T})
 
-    for T in (Float32, Float64)
-        srand(1234) # needed for getting "good" tensors for calculating det and friends
-        A = rand(Tensor{2, dim, T})
-        B = rand(Tensor{2, dim, T})
-        A_sym = rand(SymmetricTensor{2, dim, T})
-        B_sym = rand(SymmetricTensor{2, dim, T})
-        v = rand(Vec{dim, T})
-        II = one(Tensor{4, dim, T})
-        II_sym = one(SymmetricTensor{4, dim, T})
+            # Gradient of scalars
+            @test ∇(norm, v) ≈ ∇(norm, v, :all)[1] ≈ v / norm(v)
+            @test ∇(norm, v, :all)[2] ≈ norm(v)
+            @test ∇(norm, A) ≈ ∇(norm, A, :all)[1] ≈ A / norm(A)
+            @test ∇(norm, A, :all)[2] ≈ norm(A)
+            @test ∇(norm, A_sym) ≈ ∇(norm, A_sym, :all)[1] ≈ A_sym / norm(A_sym)
+            @test ∇(norm, A_sym, :all)[2] ≈ norm(A_sym)
+            @test ∇(v -> 3*v, v) ≈ ∇(v -> 3*v, v, :all)[1] ≈ diagm(Tensor{2, dim}, 3.0)
+            @test ∇(v -> 3*v, v, :all)[2] ≈ 3*v
+            # https://en.wikipedia.org/wiki/Tensor_derivative_(continuum_mechanics)#Derivatives_of_the_invariants_of_a_second-order_tensor
+            I1, DI1 = A -> trace(A), A -> one(A)
+            I2, DI2 = A -> 1/2 * (trace(A)^2 - trace(A⋅A)), A -> I1(A) * one(A) - A'
+            I3, DI3 = A -> det(A), A -> det(A) * inv(A)'
 
-        # Gradient of scalars
-        @test ∇(norm, v) ≈ ∇(norm, v, :all)[1] ≈ v / norm(v)
-        @test ∇(norm, v, :all)[2] ≈ norm(v)
-        @test ∇(norm, A) ≈ ∇(norm, A, :all)[1] ≈ A / norm(A)
-        @test ∇(norm, A, :all)[2] ≈ norm(A)
-        @test ∇(norm, A_sym) ≈ ∇(norm, A_sym, :all)[1] ≈ A_sym / norm(A_sym)
-        @test ∇(norm, A_sym, :all)[2] ≈ norm(A_sym)
-        @test ∇(v -> 3*v, v) ≈ ∇(v -> 3*v, v, :all)[1] ≈ diagm(Tensor{2, dim}, 3.0)
-        @test ∇(v -> 3*v, v, :all)[2] ≈ 3*v
-        # https://en.wikipedia.org/wiki/Tensor_derivative_(continuum_mechanics)#Derivatives_of_the_invariants_of_a_second-order_tensor
-        I1, DI1 = A -> trace(A), A -> one(A)
-        I2, DI2 = A -> 1/2 * (trace(A)^2 - trace(A⋅A)), A -> I1(A) * one(A) - A'
-        I3, DI3 = A -> det(A), A -> det(A) * inv(A)'
+            @test ∇(I1, A) ≈ ∇(I1, A, :all)[1] ≈ DI1(A)
+            @test ∇(I1, A, :all)[2] ≈ I1(A)
+            @test ∇(I2, A) ≈ ∇(I2, A, :all)[1] ≈ DI2(A)
+            @test ∇(I2, A, :all)[2] ≈ I2(A)
+            @test ∇(I3, A) ≈ ∇(I3, A, :all)[1] ≈ DI3(A)
+            @test ∇(I3, A, :all)[2] ≈ I3(A)
+            @test ∇(I1, A_sym) ≈ ∇(I1, A_sym, :all)[1] ≈ DI1(A_sym)
+            @test ∇(I1, A_sym, :all)[2] ≈ I1(A_sym)
+            @test ∇(I2, A_sym) ≈ ∇(I2, A_sym, :all)[1] ≈ DI2(A_sym)
+            @test ∇(I2, A_sym, :all)[2] ≈ I2(A_sym)
+            @test ∇(I3, A_sym) ≈ ∇(I3, A_sym, :all)[1] ≈ DI3(A_sym)
+            @test ∇(I3, A_sym, :all)[2] ≈ I3(A_sym)
 
-        @test ∇(I1, A) ≈ ∇(I1, A, :all)[1] ≈ DI1(A)
-        @test ∇(I1, A, :all)[2] ≈ I1(A)
-        @test ∇(I2, A) ≈ ∇(I2, A, :all)[1] ≈ DI2(A)
-        @test ∇(I2, A, :all)[2] ≈ I2(A)
-        @test ∇(I3, A) ≈ ∇(I3, A, :all)[1] ≈ DI3(A)
-        @test ∇(I3, A, :all)[2] ≈ I3(A)
-        @test ∇(I1, A_sym) ≈ ∇(I1, A_sym, :all)[1] ≈ DI1(A_sym)
-        @test ∇(I1, A_sym, :all)[2] ≈ I1(A_sym)
-        @test ∇(I2, A_sym) ≈ ∇(I2, A_sym, :all)[1] ≈ DI2(A_sym)
-        @test ∇(I2, A_sym, :all)[2] ≈ I2(A_sym)
-        @test ∇(I3, A_sym) ≈ ∇(I3, A_sym, :all)[1] ≈ DI3(A_sym)
-        @test ∇(I3, A_sym, :all)[2] ≈ I3(A_sym)
+            # Gradient of second order tensors
+            @test ∇(identity, A) ≈ ∇(identity, A, :all)[1] ≈ II
+            @test ∇(identity, A, :all)[2] ≈ A
+            @test ∇(identity, A_sym) ≈ ∇(identity, A_sym, :all)[1] ≈ II_sym
+            @test ∇(identity, A_sym, :all)[2] ≈ A_sym
+            @test ∇(transpose, A) ⊡ B ≈ ∇(transpose, A, :all)[1] ⊡ B ≈ B'
+            @test ∇(transpose, A, :all)[2] ≈ A'
+            @test ∇(transpose, A_sym) ⊡ B_sym ≈ ∇(transpose, A_sym, :all)[1] ⊡ B_sym ≈ B_sym'
+            @test ∇(transpose, A_sym, :all)[2] ≈ A_sym'
+            @test ∇(inv, A) ⊡ B ≈ ∇(inv, A, :all)[1] ⊡ B ≈ - inv(A) ⋅ B ⋅ inv(A)
+            @test ∇(inv, A, :all)[2] ≈ inv(A)
+            @test ∇(inv, A_sym) ⊡ B_sym ≈ ∇(inv, A_sym, :all)[1] ⊡ B_sym ≈ - inv(A_sym) ⋅ B_sym ⋅ inv(A_sym)
+            @test ∇(inv, A_sym, :all)[2] ≈ inv(A_sym)
 
-        # Gradient of second order tensors
-        @test ∇(identity, A) ≈ ∇(identity, A, :all)[1] ≈ II
-        @test ∇(identity, A, :all)[2] ≈ A
-        @test ∇(identity, A_sym) ≈ ∇(identity, A_sym, :all)[1] ≈ II_sym
-        @test ∇(identity, A_sym, :all)[2] ≈ A_sym
-        @test ∇(transpose, A) ⊡ B ≈ ∇(transpose, A, :all)[1] ⊡ B ≈ B'
-        @test ∇(transpose, A, :all)[2] ≈ A'
-        @test ∇(transpose, A_sym) ⊡ B_sym ≈ ∇(transpose, A_sym, :all)[1] ⊡ B_sym ≈ B_sym'
-        @test ∇(transpose, A_sym, :all)[2] ≈ A_sym'
-        @test ∇(inv, A) ⊡ B ≈ ∇(inv, A, :all)[1] ⊡ B ≈ - inv(A) ⋅ B ⋅ inv(A)
-        @test ∇(inv, A, :all)[2] ≈ inv(A)
-        @test ∇(inv, A_sym) ⊡ B_sym ≈ ∇(inv, A_sym, :all)[1] ⊡ B_sym ≈ - inv(A_sym) ⋅ B_sym ⋅ inv(A_sym)
-        @test ∇(inv, A_sym, :all)[2] ≈ inv(A_sym)
-
-        # Hessians of scalars
-        @test Δ(norm, A) ≈ Δ(norm, A, :all)[1] ≈ reshape(ForwardDiff.hessian(x -> sqrt(sum(abs2, x)), A), (dim, dim, dim, dim))
-        @test Array(Δ(norm, A, :all)[2]) ≈ reshape(ForwardDiff.gradient(x -> sqrt(sum(abs2, x)), A), (dim, dim))
-        @test Δ(norm, A, :all)[3] ≈ norm(A)
-    end
-end # testset
+            # Hessians of scalars
+            @test Δ(norm, A) ≈ Δ(norm, A, :all)[1] ≈ reshape(ForwardDiff.hessian(x -> sqrt(sum(abs2, x)), A), (dim, dim, dim, dim))
+            @test Array(Δ(norm, A, :all)[2]) ≈ reshape(ForwardDiff.gradient(x -> sqrt(sum(abs2, x)), A), (dim, dim))
+            @test Δ(norm, A, :all)[3] ≈ norm(A)
+            end # loop T
+        end # testsection
+    end # loop dim
+end # testsection

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -1,4 +1,4 @@
-@testset "basic constructors: rand, zero, ones" begin
+@testsection "constructors" begin
 for T in (Float32, Float64, F64), dim in (1,2,3), order in (1,2,4)
     for op in (:rand, :zero, :ones)
         # Tensor, SymmetricTensor
@@ -52,7 +52,7 @@ for T in (Float32, Float64, F64), dim in (1,2,3), order in (1,2,4)
 end
 end # of testset
 
-@testset "diagm, one" begin
+@testsection "diagm, one" begin
 for T in (Float32, Float64, F64), dim in (1,2,3)
     # diagm
     v = rand(T, dim)
@@ -112,7 +112,7 @@ for T in (Float32, Float64, F64), dim in (1,2,3)
 end
 end # of testset
 
-@testset "base vectors" begin
+@testsection "base vectors" begin
 for T in (Float32, Float64, F64), dim in (1,2,3)
     eᵢ_func(i) = Tensor{1, dim, T}(j->j==i ? one(T) : zero(T))
 
@@ -130,7 +130,7 @@ for T in (Float32, Float64, F64), dim in (1,2,3)
 end
 end # of testset
 
-@testset "simple math" begin
+@testsection "simple math" begin
 for T in (Float32, Float64), dim in (1,2,3), order in (1,2,4), TensorType in (Tensor, SymmetricTensor)
     TensorType == SymmetricTensor && order == 1 && continue
     @eval begin
@@ -161,7 +161,7 @@ for T in (Float32, Float64), dim in (1,2,3), order in (1,2,4), TensorType in (Te
 end
 end # of testset
 
-@testset "create with a function" begin
+@testsection "constrct func" begin
 for T in (Float32, Float64, F64)
     for dim in (1,2,3)
         fi = (i) -> cos(i)
@@ -204,7 +204,7 @@ for T in (Float32, Float64, F64)
 end
 end # of testset
 
-@testset "create from Array" begin
+@testsection "constrct Arr" begin
 for (T1, T2) in ((Float32, Float64), (Float64, Float32)), order in (1,2,4), dim in (1,2,3)
     At = rand(Tensor{order, dim})
     gen_data = rand(T1, size(At))
@@ -235,7 +235,7 @@ for (T1, T2) in ((Float32, Float64), (Float64, Float32)), order in (1,2,4), dim 
 end
 end # of testset
 
-@testset "indexing" begin
+@testsection "indexing" begin
 for T in (Float32, Float64, F64), dim in (1,2,3), order in (1,2,4)
     if order == 1
         data = rand(T, dim)
@@ -294,7 +294,7 @@ for T in (Float32, Float64, F64), dim in (1,2,3), order in (1,2,4)
 end
 end # of testset
 
-@testset "norm, trace, det, inv, eig" begin
+@testsection "norm, trace, det, inv, eig" begin
 for T in (Float32, Float64, F64), dim in (1,2,3)
     # norm
     for order in (1,2,4)
@@ -345,7 +345,7 @@ end
 end # of testset
 
 # https://en.wikiversity.org/wiki/Continuum_mechanics/Tensor_algebra_identities
-@testset "tensor identities" begin
+@testsection "tensor identities" begin
 for T in (Float32, Float64, F64)
     for dim in (1,2,3)
         # Identities with second order and first order
@@ -419,7 +419,7 @@ for T in (Float32, Float64, F64)
 end
 end # of testset
 
-@testset "promotion/conversion" begin
+@testsection "promotion/conversion" begin
 const T = Float32
 const WIDE_T = widen(T)
 for dim in (1,2,3), order in (1,2,4)
@@ -491,7 +491,7 @@ for dim in (1,2,3), order in (1,2,4)
 end
 end  # of testset
 
-@testset "exceptions" begin
+@testsection "exceptions" begin
     # normal multiplication
     A = rand(Tensor{2, 3})
     B = rand(Tensor{2, 3})

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -5,7 +5,8 @@ function _permutedims{dim}(S::FourthOrderTensor{dim}, idx::NTuple{4,Int})
     return Tensor{4,dim}(f)
 end
 
-@testset "tensor operations: T = $T, dim = $dim" for T in (Float32, Float64, F64), dim in (1,2,3)
+@testsection "tensor ops" begin
+for T in (Float32, Float64, F64), dim in (1,2,3)
 
 AA = rand(Tensor{4, dim, T})
 BB = rand(Tensor{4, dim, T})
@@ -21,7 +22,7 @@ B_sym = rand(SymmetricTensor{2, dim, T})
 
 i,j,k,l = rand(1:dim,4)
 
-@testset "double contraction" begin
+@testsection "double contraction" begin
     # 4 - 4
     # Value tests
     @test vec(dcontract(AA, BB)) ≈ vec(collect(reshape(vec(AA), (dim^2, dim^2))) * collect(reshape(vec(BB), (dim^2, dim^2))))
@@ -67,9 +68,9 @@ i,j,k,l = rand(1:dim,4)
     @test isa(dcontract(A_sym, B), T)
     @test isa(dcontract(A, B_sym), T)
     @test isa(dcontract(A_sym, B_sym), T)
-end # of testset
+end # of testsection
 
-@testset "outer product" begin
+@testsection "outer product" begin
     # Value tests
     @test otimes(a, b) ≈ Array(a) * Array(b)'
     @test reshape(vec(otimes(A, B)), dim^2, dim^2) ≈ vec(A) * vec(B)'
@@ -83,9 +84,9 @@ end # of testset
     @test isa(otimes(A_sym, B), Tensor{4, dim, T})
     @test isa(otimes(A, B_sym), Tensor{4, dim, T})
     @test isa(otimes(A_sym, B_sym), SymmetricTensor{4, dim, T})
-end # of testset
+end # of testsection
 
-@testset "dot products" begin
+@testsection "dot products" begin
     # 1 - 2
     # Value tests
     @test dot(a, b) ≈ sum(Array(a) .* Array(b))
@@ -127,9 +128,9 @@ end # of testset
     @test isa(tdot(A_sym), SymmetricTensor{2, dim, T})
     @test isa(dott(A), SymmetricTensor{2, dim, T})
     @test isa(dott(A_sym), SymmetricTensor{2, dim, T})
-end # of testset
+end # of testsection
 
-@testset "symmetric/skew-symmetric" begin
+@testsection "symmetric/skew-symmetric" begin
     if dim == 1 # non-symmetric tensors are symmetric
         @test issymmetric(A)
         @test issymmetric(AA)
@@ -184,9 +185,9 @@ end # of testset
     @test skew(A) ≈ -skew(A).'
     @test trace(skew(A)) ≈ 0.0
     @test trace(symmetric(A)) ≈ trace(A)
-end # of testset
+end # of testsection
 
-@testset "transpose" begin
+@testsection "transpose" begin
     @test transpose(a) ≈ a' ≈ a
     @test isa(transpose(a), Vec{dim, T})
     @test transpose(A) ≈ Array(A).'
@@ -212,9 +213,9 @@ end # of testset
     @test minortranspose(AA_sym) ≈ _permutedims(AA_sym,(2,1,4,3))
     @test majortranspose(AA) ≈ _permutedims(AA,(3,4,1,2))
     @test majortranspose(AA_sym) ≈ _permutedims(AA_sym,(3,4,1,2))
-end # of testset
+end # of testsection
 
-@testset "cross product" begin
+@testsection "cross product" begin
     @test a × a ≈ Vec{3, T}((0.0,0.0,0.0))
     @test a × b ≈ -b × a
     if dim == 2
@@ -227,14 +228,14 @@ end # of testset
         ad2 = Vec{3, T}((0.0,1.0,0.0))
         @test ad × ad2 ≈ Vec{3, T}((0.0, 0.0, 1.0))
     end
-end # of testset
+end # of testsection
 
-@testset "special" begin
+@testsection "special" begin
     AAT = Tensor{4, dim, T}((i,j,k,l) -> AA_sym[i,l,k,j])
     @test AAT ⊡ (b ⊗ a) ≈ dotdot(a, AA_sym, b)
-end # of testset
+end # of testsection
 
-@testset "rotation" begin
+@testsection "rotation" begin
     x = eᵢ(Vec{3}, 1)
     y = eᵢ(Vec{3}, 2)
     z = eᵢ(Vec{3}, 3)
@@ -249,5 +250,6 @@ end # of testset
     @test rotate(a, b, 0) ≈ a
     @test rotate(a, b, π) ≈ rotate(a, b, -π)
     @test rotate(a, b, π/2) ≈ rotate(a, -b, -π/2)
-end # of testset
-end # of testset
+end
+end # of testsection
+end # of testsection


### PR DESCRIPTION
Need a tag to TimerOutputs to work:

Ex:

```
 ─────────────────────────────────────────────────────────────────────────────────────
                                              Time                   Allocations      
                                      ──────────────────────   ───────────────────────
           Tot / % measured:                155s / 91.9%           8.86GiB / 94.8%    

 Section                      ncalls     time   %tot     avg     alloc   %tot      avg
 ─────────────────────────────────────────────────────────────────────────────────────
 AD                                1    57.0s  40.0%   57.0s   4.86GiB  57.9%  4.86GiB
   dim 3                           1    47.8s  33.5%   47.8s   4.40GiB  52.4%  4.40GiB
   dim 2                           1    6.08s  4.26%   6.08s    311MiB  3.62%   311MiB
   dim 1                           1    3.18s  2.23%   3.18s    160MiB  1.86%   160MiB
 tensor ops                        1    27.4s  19.2%   27.4s   1.09GiB  13.0%  1.09GiB
   double contraction              9    12.2s  8.52%   1.35s    484MiB  5.63%  53.8MiB
   outer product                   9    8.53s  5.98%   948ms    420MiB  4.89%  46.7MiB
   transpose                       9    2.88s  2.02%   320ms   79.1MiB  0.92%  8.79MiB
   symmetric/skew-symmetric        9    1.93s  1.35%   214ms   69.9MiB  0.81%  7.77MiB
   dot products                    9    1.14s  0.80%   126ms   35.0MiB  0.41%  3.89MiB
   special                         9    645ms  0.45%  71.6ms   28.4MiB  0.33%  3.15MiB
   cross product                   9   90.3ms  0.06%  10.0ms   2.57MiB  0.03%   292KiB
   rotation                        9    179μs  0.00%  19.8μs   40.6KiB  0.00%  4.52KiB
 constructors                      1    14.9s  10.5%   14.9s    531MiB  6.17%   531MiB
 tensor identities                 1    9.77s  6.85%   9.77s    546MiB  6.35%   546MiB
 simple math                       1    8.85s  6.20%   8.85s    399MiB  4.64%   399MiB
 constrct Arr                      1    7.89s  5.53%   7.89s    346MiB  4.03%   346MiB
 norm, trace, det, inv, eig        1    7.23s  5.07%   7.23s    266MiB  3.09%   266MiB
 indexing                          1    2.27s  1.59%   2.27s   82.8MiB  0.96%  82.8MiB
 base vectors                      1    2.13s  1.50%   2.13s    102MiB  1.18%   102MiB
 diagm, one                        1    1.96s  1.38%   1.96s   74.4MiB  0.87%  74.4MiB
 constrct func                     1    1.61s  1.13%   1.61s   88.5MiB  1.03%  88.5MiB
 promotion/conversion              1    1.58s  1.11%   1.58s   66.6MiB  0.77%  66.6MiB
 exceptions                        1   1.12ms  0.00%  1.12ms   7.89KiB  0.00%  7.89KiB
 ─────────────────────────────────────────────────────────────────────────────────────
```