### PR TITLE
Add inv for fourth order tensors

### DIFF
--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -153,6 +153,16 @@ end
     end
 end
 
+function Base.inv{dim}(t::Tensor{4, dim})
+    fromvoigt(Tensor{4, dim}, inv(tovoigt(t)))
+end
+
+function Base.inv{dim, T}(t::SymmetricTensor{4, dim, T})
+    # use mandel form to reduce order of symmetric tensor
+    s = T(√2)
+    fromvoigt(SymmetricTensor{4, dim}, inv(tovoigt(t, offdiagscale=s)), offdiagscale=s)
+end
+
 """
 ```julia
 eig(::SymmetricTensor{2})

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -333,6 +333,14 @@ for T in (Float32, Float64, F64), dim in (1,2,3)
     @test inv(t_sym) ≈ inv(Array(t_sym))
     @test isa(inv(t_sym), SymmetricTensor{2, dim, T})
 
+    # inv for forth order tensors
+    AA = rand(Tensor{4, dim, T})
+    AA_sym = rand(SymmetricTensor{4, dim, T})
+    @test AA ⊡ inv(AA) ≈ one(Tensor{4, dim, T})
+    @test isa(inv(AA), Tensor{4, dim, T})
+    @test AA_sym ⊡ inv(AA_sym) ≈ one(SymmetricTensor{4, dim, T})
+    @test isa(inv(AA_sym), SymmetricTensor{4, dim, T})
+
     E = eigfact(t_sym)
     Λ, Φ = eig(t_sym)
     Λa, Φa = eig(Array(t_sym))


### PR DESCRIPTION
This PR is to support `inv` for fourth order tensors. This is useful in some computations of continuum mechanics. The definitions of inverse of fourth order tensors are follows:

```julia
julia> A = rand(Tensor{4,3});

julia> A ⊡ inv(A) ≈ one(Tensor{4,3})
true

julia> S = rand(SymmetricTensor{4,3});

julia> S ⊡ inv(S) ≈ one(SymmetricTensor{4,3})
true
```
