### PR TITLE
Fix mean and dev

### DIFF
--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -298,7 +298,7 @@ julia> trace(A)
 end
 vol(S::SecondOrderTensor) = trace(S)
 
-Base.mean(S::SecondOrderTensor) = trace(S) / 3
+Base.mean{dim}(S::SecondOrderTensor{dim}) = trace(S) / dim
 
 """
 ```julia
@@ -323,7 +323,7 @@ julia> trace(dev(A))
 """
 @inline function dev(S::SecondOrderTensor)
     Tt = get_base(typeof(S))
-    tr = trace(S) / 3
+    tr = mean(S)
     Tt(
         @inline function(i, j)
             @inbounds  v = i == j ? S[i,j] - tr : S[i,j]

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -315,12 +315,12 @@ for T in (Float32, Float64, F64), dim in (1,2,3)
     @test trace(t) == sum([t[i,i] for i in 1:dim])
     @test trace(t_sym) == sum([t_sym[i,i] for i in 1:dim])
 
-    @test trace(t) ≈ vol(t) ≈ mean(t)*3.0
-    @test trace(t_sym) ≈ vol(t_sym) ≈ mean(t_sym)*3.0
+    @test trace(t) ≈ vol(t) ≈ mean(t)*dim
+    @test trace(t_sym) ≈ vol(t_sym) ≈ mean(t_sym)*dim
 
-    @test dev(t) ≈ Array(t) - 1/3*trace(t)*eye(dim)
+    @test dev(t) ≈ Array(t) - 1/dim*trace(t)*eye(dim)
     @test isa(dev(t), Tensor{2, dim, T})
-    @test dev(t_sym) ≈ Array(t_sym) - 1/3*trace(t_sym)*eye(dim)
+    @test dev(t_sym) ≈ Array(t_sym) - 1/dim*trace(t_sym)*eye(dim)
     @test isa(dev(t_sym), SymmetricTensor{2, dim, T})
 
     @test det(t) ≈ det(Array(t))


### PR DESCRIPTION
Currently `dev` function doesn't return a correct result for 1 and 2 dimension tensors because `3` is always used to compute volumetric part instead of `dim`.

```julia
julia> rand(Tensor{2,2}) |> dev |> trace
0.07594753985159675

julia> rand(Tensor{2,1}) |> dev |> trace
0.6577749573412563
```

This PR:
```julia
julia> rand(Tensor{2,2}) |> dev |> trace
0.0

julia> rand(Tensor{2,1}) |> dev |> trace
0.0
```

I also fixed `mean` function to use `dim` instead of `3`.

NOTE: I wanted to add tests to check this, but it sometimes failed:

```julia
julia> rand(Tensor{2,3}) |> dev |> trace ≈ 0.0
false
```