### PR TITLE
Modify vol to return tensor

### DIFF
--- a/docs/src/man/other_operators.md
+++ b/docs/src/man/other_operators.md
@@ -112,7 +112,7 @@ The skew symmetric part of a symmetric tensor is zero.
 skew
 ```
 
-## Deviator
+## Deviatoric tensor
 
 The deviatoric part of a second order tensor is defined by
 
@@ -120,6 +120,16 @@ $\mathbf{A}^\text{dev} = \mathbf{A} - \frac{1}{3} \mathrm{trace}[\mathbf{A}] \ma
 
 ```@docs
 dev
+```
+
+## Volumetric tensor
+
+The volumetric part of a second order tensor is defined by
+
+$\mathbf{A}^\text{vol} = \frac{1}{3} \mathrm{trace}[\mathbf{A}] \mathbf{I} \Leftrightarrow A_{ij}^\text{vol} = \frac{1}{3}A_{kk}\delta_{ij}$
+
+```@docs
+vol
 ```
 
 ## Cross product

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -275,7 +275,6 @@ Extract eigenvectors from an `Eigen` object, returned by [`eigfact`](@ref).
 trace(::SecondOrderTensor)
 ```
 Computes the trace of a second order tensor.
-The synonym `vol` can also be used.
 
 **Example:**
 
@@ -296,9 +295,35 @@ julia> trace(A)
     exp = reduce((ex1, ex2) -> :(+($ex1, $ex2)), ex)
     @inbounds return exp
 end
-vol(S::SecondOrderTensor) = trace(S)
 
 Base.mean(S::SecondOrderTensor) = trace(S) / 3
+
+"""
+```julia
+vol(::SecondOrderTensor)
+```
+Computes the volumetric part of a second order tensor based on the additive decomposition.
+
+**Example:**
+
+```jldoctest
+julia> A = rand(SymmetricTensor{2,3})
+3×3 Tensors.SymmetricTensor{2,3,Float64,6}:
+ 0.0339856  0.347344  0.416272
+ 0.347344   0.545664  0.885307
+ 0.416272   0.885307  0.683448
+
+julia> vol(A)
+3×3 Tensors.SymmetricTensor{2,3,Float64,6}:
+ 0.421032  0.0       0.0
+ 0.0       0.421032  0.0
+ 0.0       0.0       0.421032
+
+julia> vol(A) + dev(A) ≈ A
+true
+```
+"""
+vol(S::SecondOrderTensor) = mean(S) * one(S)
 
 """
 ```julia

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -302,22 +302,23 @@ Base.mean(S::SecondOrderTensor) = trace(S) / 3
 ```julia
 vol(::SecondOrderTensor)
 ```
-Computes the volumetric part of a second order tensor based on the additive decomposition.
+Computes the volumetric part of a second order tensor
+based on the additive decomposition.
 
 **Example:**
 
 ```jldoctest
 julia> A = rand(SymmetricTensor{2,3})
 3×3 Tensors.SymmetricTensor{2,3,Float64,6}:
- 0.0339856  0.347344  0.416272
- 0.347344   0.545664  0.885307
- 0.416272   0.885307  0.683448
+ 0.590845  0.766797  0.566237
+ 0.766797  0.460085  0.794026
+ 0.566237  0.794026  0.854147
 
 julia> vol(A)
 3×3 Tensors.SymmetricTensor{2,3,Float64,6}:
- 0.421032  0.0       0.0
- 0.0       0.421032  0.0
- 0.0       0.0       0.421032
+ 0.635026  0.0       0.0
+ 0.0       0.635026  0.0
+ 0.0       0.0       0.635026
 
 julia> vol(A) + dev(A) ≈ A
 true
@@ -334,7 +335,7 @@ Computes the deviatoric part of a second order tensor.
 **Example:**
 
 ```jldoctest
-julia> A = rand(Tensor{2,3});
+julia> A = rand(Tensor{2, 3});
 
 julia> dev(A)
 3×3 Tensors.Tensor{2,3,Float64,9}:

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -308,15 +308,20 @@ for T in (Float32, Float64, F64), dim in (1,2,3)
         end
     end
 
-    # trace, dev, det, inv (only for second order tensors)
+    # trace, vol, dev, det, inv (only for second order tensors)
     t = rand(Tensor{2, dim, T})
     t_sym = rand(SymmetricTensor{2, dim, T})
 
     @test trace(t) == sum([t[i,i] for i in 1:dim])
     @test trace(t_sym) == sum([t_sym[i,i] for i in 1:dim])
 
-    @test trace(t) ≈ vol(t) ≈ mean(t)*3.0
-    @test trace(t_sym) ≈ vol(t_sym) ≈ mean(t_sym)*3.0
+    @test trace(t) ≈ mean(t)*3.0
+    @test trace(t_sym) ≈ mean(t_sym)*3.0
+
+    @test vol(t) ≈ mean(t)*eye(dim)
+    @test isa(vol(t), Tensor{2, dim, T})
+    @test vol(t_sym) ≈ mean(t_sym)*eye(dim)
+    @test isa(vol(t_sym), SymmetricTensor{2, dim, T})
 
     @test dev(t) ≈ Array(t) - 1/3*trace(t)*eye(dim)
     @test isa(dev(t), Tensor{2, dim, T})

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -338,7 +338,7 @@ for T in (Float32, Float64, F64), dim in (1,2,3)
     @test inv(t_sym) ≈ inv(Array(t_sym))
     @test isa(inv(t_sym), SymmetricTensor{2, dim, T})
 
-    # inv for forth order tensors
+    # inv for fourth order tensors
     AA = rand(Tensor{4, dim, T})
     AA_sym = rand(SymmetricTensor{4, dim, T})
     @test AA ⊡ inv(AA) ≈ one(Tensor{4, dim, T})


### PR DESCRIPTION
Currently `vol` function is the same as `trace`, but it is more useful to return tensor. This is consistent with `dev` function.

```julia
julia> A = rand(Tensor{2,3})
3×3 Tensors.Tensor{2,3,Float64,9}:
 0.349248  0.383259    0.493558
 0.327233  0.0432712   0.0638624
 0.687384  0.00967807  0.654179

julia> vol(A) + dev(A) ≈ A
true
```