### PR TITLE
remove unnecessary promotions

### DIFF
--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -38,8 +38,6 @@ end
 ###############
 @compat const Vec{dim, T, M} = Tensor{1, dim, T, dim}
 
-@compat const AnyTensor{order, dim, T} = Union{SymmetricTensor{order, dim, T}, Tensor{order, dim, T}}
-
 @compat const AllTensors{dim, T} = Union{SymmetricTensor{2, dim, T}, Tensor{2, dim, T},
                                          SymmetricTensor{4, dim, T}, Tensor{4, dim, T},
                                          Vec{dim, T}}

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -38,6 +38,8 @@ end
 ###############
 @compat const Vec{dim, T, M} = Tensor{1, dim, T, dim}
 
+@compat const AnyTensor{order, dim, T} = Union{SymmetricTensor{order, dim, T}, Tensor{order, dim, T}}
+
 @compat const AllTensors{dim, T} = Union{SymmetricTensor{2, dim, T}, Tensor{2, dim, T},
                                          SymmetricTensor{4, dim, T}, Tensor{4, dim, T},
                                          Vec{dim, T}}

--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -4,30 +4,31 @@
 
 # Unary
 @inline Base.:+{T <: AbstractTensor}(S::T) = S
-@inline Base.:-{T <: AbstractTensor}(S::T) = map(-, S)
+@inline Base.:-{T <: AbstractTensor}(S::T) = _map(-, S)
 
 # Binary
-@inline Base.:+{order, dim, T}(S1::Tensor{order, dim, T}, S2::Tensor{order, dim, T}) = map(+, S1, S2)
-@inline Base.:+{order, dim, T}(S1::SymmetricTensor{order, dim, T}, S2::SymmetricTensor{order, dim, T}) = map(+, S1, S2)
-@inline Base.:+{order, dim}(S1::AbstractTensor{order, dim}, S2::AbstractTensor{order, dim}) = +(promote(S1, S2)...)
-@inline Base.:-{order, dim, T}(S1::Tensor{order, dim, T}, S2::Tensor{order, dim, T}) = map(-, S1, S2)
-@inline Base.:-{order, dim, T}(S1::SymmetricTensor{order, dim, T}, S2::SymmetricTensor{order, dim, T}) = map(-, S1, S2)
-@inline Base.:-{order, dim}(S1::AbstractTensor{order, dim}, S2::AbstractTensor{order, dim}) = -(promote(S1, S2)...)
+@inline Base.:+{order, dim}(S1::Tensor{order, dim}, S2::Tensor{order, dim}) = _map(+, S1, S2)
+@inline Base.:+{order, dim}(S1::SymmetricTensor{order, dim}, S2::SymmetricTensor{order, dim}) = _map(+, S1, S2)
+@inline Base.:-{order, dim}(S1::Tensor{order, dim}, S2::Tensor{order, dim}) = _map(-, S1, S2)
+@inline Base.:-{order, dim}(S1::SymmetricTensor{order, dim}, S2::SymmetricTensor{order, dim}) = _map(-, S1, S2)
+@inline Base.:-{order, dim}(S1::AnyTensor{order, dim}, S2::AnyTensor{order, dim}) =  ((SS1, SS2) = promote(S1, S2); _map(-, SS1, SS2))
+@inline Base.:+{order, dim}(S1::AnyTensor{order, dim}, S2::AnyTensor{order, dim}) =  ((SS1, SS2) = promote(S1, S2); _map(+, SS1, SS2))
 
-@inline Base.:+(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimension and order must match"))
-@inline Base.:-(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimension and order must match"))
+@inline Base.:*(S::AbstractTensor, n::Number) = _map(x -> x*n, S)
+@inline Base.:*(n::Number, S::AbstractTensor) = _map(x -> n*x, S)
+@inline Base.:/(S::AbstractTensor, n::Number) = _map(x -> x/n, S)
 
-@inline Base.:*(S::AbstractTensor, n::Number) = map(x->(x*n), S)
-@inline Base.:*(n::Number, S::AbstractTensor) = map(x->(n*x), S)
-@inline Base.:/(S::AbstractTensor, n::Number) = map(x->(x/n), S)
+Base.:+(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimension and order must match"))
+Base.:-(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimension and order must match"))
 
 # map implementations
-@inline function Base.map{T <: AbstractTensor}(f, S::T)
+@inline function _map{T <: AbstractTensor}(f, S::T)
     return apply_all(S, @inline function(i) @inboundsret f(S.data[i]); end)
 end
 
-@inline Base.map{order, dim, T1, T2}(f, S1::AbstractTensor{order, dim, T1}, S2::AbstractTensor{order, dim, T2}) = ((SS1, SS2) = promote(S1, S2); map(f, SS1, SS2))
+_map{order, dim}(f, S1::Tensor{order, dim}, S2::SymmetricTensor{order, dim}) = ((SS1, SS2) = promote(S1, S2); _map(f, SS1, SS2))
+_map{order, dim}(f, S1::SymmetricTensor{order, dim}, S2::Tensor{order, dim}) = ((SS1, SS2) = promote(S1, S2); _map(f, SS1, SS2))
 
-@inline function Base.map{T <: AllTensors}(f, S1::T, S2::T)
+@inline function _map(f, S1::AllTensors, S2::AllTensors)
     return apply_all(S1, @inline function(i) @inboundsret f(S1.data[i], S2.data[i]); end)
 end

--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -3,16 +3,17 @@
 ###############
 
 # Unary
-@inline Base.:+{T <: AbstractTensor}(S::T) = S
-@inline Base.:-{T <: AbstractTensor}(S::T) = _map(-, S)
+@inline Base.:+(S::AbstractTensor) = S
+@inline Base.:-(S::AbstractTensor) = _map(-, S)
 
 # Binary
 @inline Base.:+{order, dim}(S1::Tensor{order, dim}, S2::Tensor{order, dim}) = _map(+, S1, S2)
 @inline Base.:+{order, dim}(S1::SymmetricTensor{order, dim}, S2::SymmetricTensor{order, dim}) = _map(+, S1, S2)
+@inline Base.:+{order, dim}(S1::AbstractTensor{order, dim}, S2::AbstractTensor{order, dim}) = ((SS1, SS2) = promote_base(S1, S2); _map(+, SS1, SS2))
+
 @inline Base.:-{order, dim}(S1::Tensor{order, dim}, S2::Tensor{order, dim}) = _map(-, S1, S2)
 @inline Base.:-{order, dim}(S1::SymmetricTensor{order, dim}, S2::SymmetricTensor{order, dim}) = _map(-, S1, S2)
-@inline Base.:-{order, dim}(S1::AnyTensor{order, dim}, S2::AnyTensor{order, dim}) =  ((SS1, SS2) = promote(S1, S2); _map(-, SS1, SS2))
-@inline Base.:+{order, dim}(S1::AnyTensor{order, dim}, S2::AnyTensor{order, dim}) =  ((SS1, SS2) = promote(S1, S2); _map(+, SS1, SS2))
+@inline Base.:-{order, dim}(S1::AbstractTensor{order, dim}, S2::AbstractTensor{order, dim}) = ((SS1, SS2) = promote_base(S1, S2); _map(-, SS1, SS2))
 
 @inline Base.:*(S::AbstractTensor, n::Number) = _map(x -> x*n, S)
 @inline Base.:*(n::Number, S::AbstractTensor) = _map(x -> n*x, S)
@@ -22,13 +23,12 @@ Base.:+(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimen
 Base.:-(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimension and order must match"))
 
 # map implementations
-@inline function _map{T <: AbstractTensor}(f, S::T)
+@inline function _map(f, S::AbstractTensor)
     return apply_all(S, @inline function(i) @inboundsret f(S.data[i]); end)
 end
 
-_map{order, dim}(f, S1::Tensor{order, dim}, S2::SymmetricTensor{order, dim}) = ((SS1, SS2) = promote(S1, S2); _map(f, SS1, SS2))
-_map{order, dim}(f, S1::SymmetricTensor{order, dim}, S2::Tensor{order, dim}) = ((SS1, SS2) = promote(S1, S2); _map(f, SS1, SS2))
-
+# the caller of 2 arg _map MUST guarantee that both arguments have
+# the same base (Tensor{order, dim} / SymmetricTensor{order, dim}) but not necessarily the same eltype
 @inline function _map(f, S1::AllTensors, S2::AllTensors)
     return apply_all(S1, @inline function(i) @inboundsret f(S1.data[i], S2.data[i]); end)
 end

--- a/src/promotion_conversion.jl
+++ b/src/promotion_conversion.jl
@@ -25,6 +25,13 @@ end
     Tensor{order, dim, promote_type(A, B), M1}
 end
 
+# define a base promotion that only promotes SymmetricTensor to Tensor but leaves eltype
+@inline function promote_base{order, dim}(S1::Tensor{order, dim}, S2::SymmetricTensor{order, dim})
+    return S1, convert(Tensor{order, dim}, S2)
+end
+@inline function promote_base{order, dim}(S1::SymmetricTensor{order, dim}, S2::Tensor{order, dim})
+    return convert(Tensor{order, dim}, S1), S2
+end
 
 ###############
 # Conversions #

--- a/src/promotion_conversion.jl
+++ b/src/promotion_conversion.jl
@@ -5,22 +5,22 @@
 # Promotion between two tensors promote the eltype and promotes
 # symmetric tensors to tensors
 
-function Base.promote_rule{dim , A <: Number, B <: Number, order, M}(::Type{SymmetricTensor{order, dim, A, M}},
+@inline function Base.promote_rule{dim , A <: Number, B <: Number, order, M}(::Type{SymmetricTensor{order, dim, A, M}},
                                                                      ::Type{SymmetricTensor{order, dim, B, M}})
     SymmetricTensor{order, dim, promote_type(A, B), M}
 end
 
-function Base.promote_rule{dim , A <: Number, B <: Number, order, M}(::Type{Tensor{order, dim, A, M}},
+@inline function Base.promote_rule{dim , A <: Number, B <: Number, order, M}(::Type{Tensor{order, dim, A, M}},
                                                                      ::Type{Tensor{order, dim, B, M}})
     Tensor{order, dim, promote_type(A, B), M}
 end
 
-function Base.promote_rule{dim , A <: Number, B <: Number, order, M1, M2}(::Type{SymmetricTensor{order, dim, A, M1}},
+@inline function Base.promote_rule{dim , A <: Number, B <: Number, order, M1, M2}(::Type{SymmetricTensor{order, dim, A, M1}},
                                                                           ::Type{Tensor{order, dim, B, M2}})
     Tensor{order, dim, promote_type(A, B), M2}
 end
 
-function Base.promote_rule{dim , A <: Number, B <: Number, order, M1, M2}(::Type{Tensor{order, dim, A, M1}},
+@inline function Base.promote_rule{dim , A <: Number, B <: Number, order, M1, M2}(::Type{Tensor{order, dim, A, M1}},
                                                                           ::Type{SymmetricTensor{order, dim, B, M2}})
     Tensor{order, dim, promote_type(A, B), M1}
 end


### PR DESCRIPTION
Let things promote at the elementwise level instead.

Benchmark:

```jl
using Tensors

function u_ana{T}(x::Vec{2, T}) 
    xs = (Vec{2}((-0.5,  0.5)),
          Vec{2}((-0.5, -0.5)),
          Vec{2}(( 0.5,  -0.5)))
    σ = 1/8
    s = zero(eltype(x))
    for i in 1:3
        s += exp(- norm(x - xs[i])^2 / σ^2)
    end
    return max(1e-15 * one(T), s) # Denormals, be gone
end

const ud2 = Tensors._load(rand(Vec{2}))
```


## Master 0.5:
```
julia> @btime u_ana($ud2)
  422.688 ns (12 allocations: 912 bytes)
```
## Master 0.6:
```
julia> @btime u_ana($ud2)
  87.265 ns (0 allocations: 0 bytes)
```
## PR:
```
julia> @btime u_ana($ud2)
  71.876 ns (0 allocations: 0 bytes)
```