### PR TITLE
Add feature: differentiation by prime notation

### DIFF
--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -11,6 +11,7 @@ export otimes, ⊗, ⊡, dcontract, dev, vol, symmetric, skew, minorsymmetric, m
 export minortranspose, majortranspose, isminorsymmetric, ismajorsymmetric
 export tdot, dott, dotdot
 export hessian#, gradient
+export By
 export basevec, eᵢ
 export rotate
 export tovoigt, fromvoigt, tomandel, frommandel
@@ -121,6 +122,7 @@ include("indexing.jl")
 include("utilities.jl")
 include("tensor_ops_errors.jl")
 include("automatic_differentiation.jl")
+include("prime_differentiation.jl")
 include("promotion_conversion.jl")
 include("constructors.jl")
 include("basic_operations.jl")

--- a/src/prime_differentiation.jl
+++ b/src/prime_differentiation.jl
@@ -23,8 +23,8 @@ end
 
 @inline (p::PrimeDiff)(x) = gradient(p.f, x)
 
-macro use_prime_diff()
-    :(@inline Base.ctranspose{F <: Function}(f::F) = PrimeDiff{1}(f))
+function use_prime_diff()
+    @inline Base.ctranspose{F <: Function}(f::F) = Tensors.PrimeDiff{1}(f)
 end
 
 immutable By{N} end

--- a/src/prime_differentiation.jl
+++ b/src/prime_differentiation.jl
@@ -1,0 +1,50 @@
+immutable PrimeDiff{N, F}
+    f::F
+end
+
+@generated function (::Type{PrimeDiff{N}}){N, F}(f::F)
+    ex = :(PrimeDiff{1, F}(f))
+    for i in 2:N
+        ex = :(_add_prime($ex))
+    end
+    return quote
+        $(Expr(:meta, :inline))
+        $ex
+    end
+end
+
+@generated function _add_prime{N}(p::PrimeDiff{N})
+    return quote
+        $(Expr(:meta, :inline))
+        PrimeDiff{$(N+1), typeof(p)}(p)
+    end
+end
+@inline Base.ctranspose{N}(p::PrimeDiff{N}) = _add_prime(p)
+
+@inline (p::PrimeDiff)(x) = gradient(p.f, x)
+
+macro use_prime_diff()
+    :(@inline Base.ctranspose{F <: Function}(f::F) = PrimeDiff{1}(f))
+end
+
+immutable By{N} end
+
+@generated function (p::PrimeDiff{N}){N, M}(::Type{By{M}}, xs...)
+    args = [i == M ? :x : :(xs[$i]) for i in 1:length(xs)]
+    return quote
+        $(Expr(:meta, :inline))
+        g = x -> _original_function(p)($(args...))
+        PrimeDiff{N}(g)(xs[M])
+    end
+end
+
+@generated function _original_function{N}(p::PrimeDiff{N})
+    ex = :(p.f)
+    for i in 2:N
+        ex = :($ex.f)
+    end
+    return quote
+        $(Expr(:meta, :inline))
+        $ex
+    end
+end

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -1,3 +1,4 @@
+Tensors.@use_prime_diff
 const ∇ = Tensors.gradient
 const Δ = Tensors.hessian
 
@@ -27,12 +28,12 @@ S(C) = S(C, μ, Kb)
         C = tdot(F);
         C2 = F' ⋅ F;
 
-        @test 2∇(Ψ, C) ≈ S(C)
-        @test 2∇(Ψ, C2) ≈ S(C2)
+        @test 2∇(Ψ, C) ≈ 2Ψ'(By{1}, C) ≈ S(C)
+        @test 2∇(Ψ, C2) ≈ 2Ψ'(By{1}, C2) ≈ S(C2)
 
         b = rand(SymmetricTensor{2, dim})
-        @test 2 * Δ(Ψ, C) ⊡ b ≈ ∇(S, C) ⊡ b
-        @test 2 * Δ(Ψ, C2) ⊡ b ≈ ∇(S, C2) ⊡ b
+        @test 2 * Δ(Ψ, C) ⊡ b ≈ 2Ψ''(By{1}, C) ⊡ b ≈ ∇(S, C) ⊡ b
+        @test 2 * Δ(Ψ, C2) ⊡ b ≈ 2Ψ''(By{1}, C2) ⊡ b ≈ ∇(S, C2) ⊡ b
 
         @test ∇(Ψ, C) ≈ ∇(Ψ, C2)
         @test ∇(S, C) ⊡ b ≈ ∇(S, C2) ⊡ b
@@ -50,16 +51,16 @@ S(C) = S(C, μ, Kb)
 
             # Gradient of scalars
             @testsection "scalar grad" begin
-                @test ∇(norm, v) ≈ ∇(norm, v, :all)[1] ≈ v / norm(v)
+                @test ∇(norm, v) ≈ ∇(norm, v, :all)[1] ≈ norm'(v) ≈ v / norm(v)
                 @test ∇(norm, v, :all)[2] ≈ norm(v)
-                @test ∇(norm, A) ≈ ∇(norm, A, :all)[1] ≈ A / norm(A)
+                @test ∇(norm, A) ≈ ∇(norm, A, :all)[1] ≈ norm'(A) ≈ A / norm(A)
                 @test ∇(norm, A, :all)[2] ≈ norm(A)
-                @test ∇(norm, A_sym) ≈ ∇(norm, A_sym, :all)[1] ≈ A_sym / norm(A_sym)
+                @test ∇(norm, A_sym) ≈ ∇(norm, A_sym, :all)[1] ≈ norm'(A_sym) ≈ A_sym / norm(A_sym)
                 @test ∇(norm, A_sym, :all)[2] ≈ norm(A_sym)
-                @test ∇(v -> 3*v, v) ≈ ∇(v -> 3*v, v, :all)[1] ≈ diagm(Tensor{2, dim}, 3.0)
+                @test ∇(v -> 3*v, v) ≈ ∇(v -> 3*v, v, :all)[1] ≈ (v -> 3*v)'(v) ≈ diagm(Tensor{2, dim}, 3.0)
                 @test ∇(v -> 3*v, v, :all)[2] ≈ 3*v
                 # function does not return dual
-                @test ∇(A -> 1, A) ≈ ∇(A -> 1, A, :all)[1] ≈ zero(Tensor{2, dim, Int})
+                @test ∇(A -> 1, A) ≈ ∇(A -> 1, A, :all)[1] ≈ (A -> 1)'(A) ≈ zero(Tensor{2, dim, Int})
                 @test ∇(A -> 1, A, :all)[2] == 1
                 @test isa(∇(A -> 1, A), Tensor{2, dim, Int})
             end
@@ -71,44 +72,44 @@ S(C) = S(C, μ, Kb)
                 I2, DI2 = A -> 1/2 * (trace(A)^2 - trace(A⋅A)), A -> I1(A) * one(A) - A'
                 I3, DI3 = A -> det(A), A -> det(A) * inv(A)'
 
-                @test ∇(I1, A) ≈ ∇(I1, A, :all)[1] ≈ DI1(A)
+                @test ∇(I1, A) ≈ ∇(I1, A, :all)[1] ≈ I1'(A) ≈ DI1(A)
                 @test ∇(I1, A, :all)[2] ≈ I1(A)
-                @test ∇(I2, A) ≈ ∇(I2, A, :all)[1] ≈ DI2(A)
+                @test ∇(I2, A) ≈ ∇(I2, A, :all)[1] ≈ I2'(A) ≈ DI2(A)
                 @test ∇(I2, A, :all)[2] ≈ I2(A)
-                @test ∇(I3, A) ≈ ∇(I3, A, :all)[1] ≈ DI3(A)
+                @test ∇(I3, A) ≈ ∇(I3, A, :all)[1] ≈ I3'(A) ≈ DI3(A)
                 @test ∇(I3, A, :all)[2] ≈ I3(A)
-                @test ∇(I1, A_sym) ≈ ∇(I1, A_sym, :all)[1] ≈ DI1(A_sym)
+                @test ∇(I1, A_sym) ≈ ∇(I1, A_sym, :all)[1] ≈ I1'(A_sym) ≈ DI1(A_sym)
                 @test ∇(I1, A_sym, :all)[2] ≈ I1(A_sym)
-                @test ∇(I2, A_sym) ≈ ∇(I2, A_sym, :all)[1] ≈ DI2(A_sym)
+                @test ∇(I2, A_sym) ≈ ∇(I2, A_sym, :all)[1] ≈ I2'(A_sym) ≈ DI2(A_sym)
                 @test ∇(I2, A_sym, :all)[2] ≈ I2(A_sym)
-                @test ∇(I3, A_sym) ≈ ∇(I3, A_sym, :all)[1] ≈ DI3(A_sym)
+                @test ∇(I3, A_sym) ≈ ∇(I3, A_sym, :all)[1] ≈ I3'(A_sym) ≈ DI3(A_sym)
                 @test ∇(I3, A_sym, :all)[2] ≈ I3(A_sym)
 
-                @test ∇(identity, A) ≈ ∇(identity, A, :all)[1] ≈ II
+                @test ∇(identity, A) ≈ ∇(identity, A, :all)[1] ≈ identity'(A) ≈ II
                 @test ∇(identity, A, :all)[2] ≈ A
-                @test ∇(identity, A_sym) ≈ ∇(identity, A_sym, :all)[1] ≈ II_sym
+                @test ∇(identity, A_sym) ≈ ∇(identity, A_sym, :all)[1] ≈ identity'(A_sym) ≈ II_sym
                 @test ∇(identity, A_sym, :all)[2] ≈ A_sym
-                @test ∇(transpose, A) ⊡ B ≈ ∇(transpose, A, :all)[1] ⊡ B ≈ B'
+                @test ∇(transpose, A) ⊡ B ≈ ∇(transpose, A, :all)[1] ⊡ B ≈ transpose'(A) ⊡ B ≈ B'
                 @test ∇(transpose, A, :all)[2] ≈ A'
-                @test ∇(transpose, A_sym) ⊡ B_sym ≈ ∇(transpose, A_sym, :all)[1] ⊡ B_sym ≈ B_sym'
+                @test ∇(transpose, A_sym) ⊡ B_sym ≈ ∇(transpose, A_sym, :all)[1] ⊡ B_sym ≈ transpose'(A_sym) ⊡ B_sym ≈ B_sym'
                 @test ∇(transpose, A_sym, :all)[2] ≈ A_sym'
-                @test ∇(inv, A) ⊡ B ≈ ∇(inv, A, :all)[1] ⊡ B ≈ - inv(A) ⋅ B ⋅ inv(A)
+                @test ∇(inv, A) ⊡ B ≈ ∇(inv, A, :all)[1] ⊡ B ≈ inv'(A) ⊡ B ≈ - inv(A) ⋅ B ⋅ inv(A)
                 @test ∇(inv, A, :all)[2] ≈ inv(A)
-                @test ∇(inv, A_sym) ⊡ B_sym ≈ ∇(inv, A_sym, :all)[1] ⊡ B_sym ≈ - inv(A_sym) ⋅ B_sym ⋅ inv(A_sym)
+                @test ∇(inv, A_sym) ⊡ B_sym ≈ ∇(inv, A_sym, :all)[1] ⊡ B_sym ≈ inv'(A_sym) ⊡ B_sym ≈ - inv(A_sym) ⋅ B_sym ⋅ inv(A_sym)
                 @test ∇(inv, A_sym, :all)[2] ≈ inv(A_sym)
                 # function does not return dual
-                @test ∇(A -> B, A) ≈ ∇(A -> B, A, :all)[1] ≈ zero(Tensor{4, dim, T})
+                @test ∇(A -> B, A) ≈ ∇(A -> B, A, :all)[1] ≈ (A->B)'(A) ≈ zero(Tensor{4, dim, T})
                 @test ∇(A -> B, A, :all)[2] ≈ B
                 @test isa(∇(A -> B, A), Tensor{4, dim, T})
             end
 
             # Hessians of scalars
             @testsection "hessian" begin
-                @test Δ(norm, A) ≈ Δ(norm, A, :all)[1] ≈ reshape(ForwardDiff.hessian(x -> sqrt(sum(abs2, x)), A), (dim, dim, dim, dim))
+                @test Δ(norm, A) ≈ Δ(norm, A, :all)[1] ≈ norm''(A) ≈ reshape(ForwardDiff.hessian(x -> sqrt(sum(abs2, x)), A), (dim, dim, dim, dim))
                 @test Array(Δ(norm, A, :all)[2]) ≈ reshape(ForwardDiff.gradient(x -> sqrt(sum(abs2, x)), A), (dim, dim))
                 @test Δ(norm, A, :all)[3] ≈ norm(A)
                 # function does not return dual
-                @test Δ(A -> 1, A) ≈ Δ(A -> 1, A, :all)[1] ≈ zero(Tensor{4, dim, Int})
+                @test Δ(A -> 1, A) ≈ Δ(A -> 1, A, :all)[1] ≈ (A->1)''(A) ≈ zero(Tensor{4, dim, Int})
                 @test Δ(A -> 1, A, :all)[2] ≈ zero(Tensor{2, dim, Int})
                 @test Δ(A -> 1, A, :all)[3] == 1
                 @test isa(Δ(A -> 1, A), Tensor{4, dim, Int})

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -1,4 +1,4 @@
-Tensors.@use_prime_diff
+Tensors.use_prime_diff()
 const ∇ = Tensors.gradient
 const Δ = Tensors.hessian
 


### PR DESCRIPTION
This PR is to support the prime notation for differentiation. In Tensors.jl package, we can always use `gradient` for differentiation, which means if we have the prime notation like [Calculus.jl](https://github.com/johnmyleswhite/Calculus.jl), we can use it for all of functions. Although this feature is not necessary for computations, we can improve readability of code.

```julia
julia> A = rand(SymmetricTensor{2, 2});

julia> norm'(A) ≈ gradient(norm, A)
true

julia> norm''(A) ≈ hessian(norm, A)
true

julia> E = rand(Tensor{4,2});

julia> ψ(ϵ) = 1/2 * ϵ ⊡ E ⊡ ϵ;

julia> ϵ = rand(Tensor{2,2});

julia> ψ''(ϵ)  ≈ hessian(ψ, ϵ)
true
```

However, someone doesn't like this feature and may have their own `ctranspose` definition for functions. So I added a macro `@use_prime_diff` to enable this feature.

```julia
julia> using Tensors

julia> @which trace'
ctranspose(f::Function) at /Users/nakamura/.julia/v0.5/Calculus/src/derivative.jl:26
```

```julia
julia> using Tensors

julia> Tensors.@use_prime_diff

julia> @which trace'
ctranspose{#84#F<:Function}(f::#84#F) at /Users/nakamura/.julia/v0.5/Tensors/src/prime_differentiation.jl:27
```

Also I added one more feature for functions having several arguments.

```julia
julia> f(x, y) = trace(x) + norm(y)
f (generic function with 1 method)

julia> A = rand(Tensor{2,3}); B = rand(Tensor{2,3});

julia> f'(By{1}, A, B) # differentiate `f` by `x` (first argument).
3×3 Tensors.Tensor{2,3,Float64,9}:
 1.0  0.0  0.0
 0.0  1.0  0.0
 0.0  0.0  1.0

julia> f'(By{2}, A, B); # differentiate `f` by `y` (second argument).

jjulia> gradient(x -> gradient(y -> f(A, y), x), B) ≈ (y -> f(A, y))''(B) ≈ f''(By{2}, A, B)
true
```