### PR TITLE
use literal pow on 0.6 and make power typestable on 0.5

### DIFF
--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -19,22 +19,6 @@
 @inline Base.:*(n::Number, S::AbstractTensor) = _map(x -> n*x, S)
 @inline Base.:/(S::AbstractTensor, n::Number) = _map(x -> x/n, S)
 
-# squaring method should be used for performance
-function Base.:^(S::SecondOrderTensor, p::Int)
-    if p == 1
-        return S
-    elseif p == 0
-        return one(S)
-    elseif p < 0
-        return inv(S)^(-p)
-    end
-    t = S
-    for _ in 2:p
-        t = t ⋅ S
-    end
-    return t
-end
-
 Base.:+(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimension and order must match"))
 Base.:-(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimension and order must match"))
 
@@ -47,4 +31,47 @@ end
 # the same base (Tensor{order, dim} / SymmetricTensor{order, dim}) but not necessarily the same eltype
 @inline function _map(f, S1::AllTensors, S2::AllTensors)
     return apply_all(S1, @inline function(i) @inboundsret f(S1.data[i], S2.data[i]); end)
+end
+
+# power
+@static if VERSION >= v"0.6.0-pre.alpha.108"
+    @inline Base.literal_pow(::typeof(^), S::SecondOrderTensor,   ::Type{Val{-1}}) = inv(S)
+    @inline Base.literal_pow(::typeof(^), S::SecondOrderTensor,   ::Type{Val{0}})  = one(S)
+    @inline Base.literal_pow(::typeof(^), S::SecondOrderTensor,   ::Type{Val{1}})  = S
+    @inline function Base.literal_pow{p}(::typeof(^), S1::SecondOrderTensor, ::Type{Val{p}})
+        p > 0 ? (S2 = S1; q = p) : (S2 = inv(S1); q = -p)
+        S3 = S2
+        for i in 2:q
+            S2 = _powdot(S2, S3)
+        end
+        S2
+    end
+else # 0.5
+    @inline function Base.:^(S1::SecondOrderTensor, p::Int)
+        p == -1 && return inv(S1)
+        p ==  0 && return one(S1)
+        p ==  1 && return S1
+        p <   0 && return inv(S1)^-p
+        S2 = S1
+        for i in 2:p
+            S2 = _powdot(S2, S1)
+        end
+        S2
+    end
+end
+
+@inline _powdot(S1::Tensor, S2::Tensor) = dot(S1, S2)
+@generated function _powdot{dim}(S1::SymmetricTensor{2, dim}, S2::SymmetricTensor{2, dim})
+    idxS1(i, j) = compute_index(get_base(S1), i, j)
+    idxS2(i, j) = compute_index(get_base(S2), i, j)
+    exps = Expr(:tuple)
+    for j in 1:dim, i in j:dim
+        ex1 = Expr[:(get_data(S1)[$(idxS1(i, k))]) for k in 1:dim]
+        ex2 = Expr[:(get_data(S2)[$(idxS2(k, j))]) for k in 1:dim]
+        push!(exps.args, reducer(ex1, ex2))
+    end
+    quote
+        $(Expr(:meta, :inline))
+        @inbounds return SymmetricTensor{2, dim}($exps)
+    end
 end

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -165,7 +165,7 @@ for T in (Float32, Float64), dim in (1,2,3), order in (1,2,4), TensorType in (Te
             @test t^2 ≈ t ⋅ t
             @test t^3 ≈ t ⋅ t ⋅ t
             @test t^-1 ≈ inv(t)
-            @test t^-2 ≈ inv(t)^2
+            @test t^-2 ≈ inv(t) ⋅ inv(t)
         end
     end
 end

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -159,13 +159,14 @@ for T in (Float32, Float64), dim in (1,2,3), order in (1,2,4), TensorType in (Te
         @test isa(-t, $TensorType{$order, $dim})
 
         if $order == 2
-            # Power integer: ^
-            @test t^0 ≈ one(t)
-            @test t^1 ≈ t
-            @test t^2 ≈ t ⋅ t
-            @test t^3 ≈ t ⋅ t ⋅ t
-            @test t^-1 ≈ inv(t)
-            @test t^-2 ≈ inv(t) ⋅ inv(t)
+            # Power by literal integer
+            @test (t^0)::typeof(t)  ≈ one(t)
+            @test (t^1)::typeof(t)  ≈ t
+            @test (t^2)::typeof(t)  ≈ t ⋅ t
+            @test (t^3)::typeof(t)  ≈ t ⋅ t ⋅ t
+            @test (t^-1)::typeof(t) ≈ inv(t)
+            @test (t^-2)::typeof(t) ≈ inv(t) ⋅ inv(t)
+            @test (t^-3)::typeof(t) ≈ inv(t) ⋅ inv(t) ⋅ inv(t)
         end
     end
 end


### PR DESCRIPTION
use the new `literal_pow` on 0.6 and restrict to powers of -1, 0 and 1.

Note that the implementation on master is type-unstable for other powers when used with a `SymmetricTensor`.

Did you have a real use case for other powers @KeitaNakamura ?