### PR TITLE
set minimum julia version to 0.6.0-pre.alpha.108

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre.alpha.108
 ForwardDiff
 SIMD


### PR DESCRIPTION
since literal_pow wouldn't work before that, and new syntax like struct, where, etc
wouldn't work for very early 0.6.0-dev versions, would be better to use the 0.5-compatible
versions of the package for those julia versions