### PR TITLE
Rotations

### DIFF
--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -112,10 +112,6 @@ end
 # @inline          Tensor{order, dim, T, M}(data::Union{AbstractArray, Tuple, Function})  where {order, dim, T, M} = Tensor{order, dim, T}(data)
 # @inline SymmetricTensor{order, dim, T, M}(data::Union{AbstractArray, Tuple, Function})  where {order, dim, T, M} = SymmetricTensor{order, dim, T}(data)
 
-# Generic fallback for higher-dimensional tensors
-@inline Tensor{order, dim}(t::NTuple{N, T}) where {order, dim, T, N} = Tensor{order, dim, T, N}(t)
-@inline SymmetricTensor{order, dim}(t::NTuple{N, T}) where {order, dim, T, N} = SymmetricTensor{order, dim, T, N}(t)
-
 include("indexing.jl")
 include("utilities.jl")
 include("tensor_ops_errors.jl")

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -112,6 +112,9 @@ end
 # @inline          Tensor{order, dim, T, M}(data::Union{AbstractArray, Tuple, Function})  where {order, dim, T, M} = Tensor{order, dim, T}(data)
 # @inline SymmetricTensor{order, dim, T, M}(data::Union{AbstractArray, Tuple, Function})  where {order, dim, T, M} = SymmetricTensor{order, dim, T}(data)
 
+# Generic fallback for higher-dimensional tensors
+@inline Tensor{order, dim}(t::NTuple{N, T}) where {order, dim, T, N} = Tensor{order, dim, T, N}(t)
+
 include("indexing.jl")
 include("utilities.jl")
 include("tensor_ops_errors.jl")

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -114,6 +114,7 @@ end
 
 # Generic fallback for higher-dimensional tensors
 @inline Tensor{order, dim}(t::NTuple{N, T}) where {order, dim, T, N} = Tensor{order, dim, T, N}(t)
+@inline SymmetricTensor{order, dim}(t::NTuple{N, T}) where {order, dim, T, N} = SymmetricTensor{order, dim, T, N}(t)
 
 include("indexing.jl")
 include("utilities.jl")

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -185,3 +185,11 @@ function rotor(u::Vec{dim}, v::Vec{dim}, θ::Number) where {dim}
     # generalized-rotation-matrix-in-n-dimensional-space-around-n-2-unit-vector
     one(Tensor{2, dim}) + sin(θ)*(otimes(v, u) - otimes(u, v)) + (cos(θ)-1)*(otimes(u) + otimes(v))
 end
+
+function rotor(u::Vec{3}, θ::Number)
+    # See http://mathworld.wolfram.com/RodriguesRotationFormula.html
+    u = u / norm(u)
+    z = zero(eltype(u))
+    ω̃ = Tensor{2, 3}((z, u[3], -u[2], -u[3], z, u[1], u[2], -u[1], z))
+    one(Tensor{2, 3}) + sin(θ)*ω̃ + (1 - cos(θ))*ω̃^2
+end

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -169,3 +169,19 @@ end
 @inline basevec(v::Vec{dim, T}, i::Int) where {dim, T} = basevec(typeof(v), i)
 
 const eᵢ = basevec
+
+"""
+```julia
+rotor(u::Vec{3}, θ::Number)
+rotor(u::Vec{dim}, v::Vec{dim}, θ::Number)
+```
+Return a rotation matrix corresponding to a rotation around the vector `u`
+by `θ` radians in three dimensions. If two orthonormal vectors `u` and `v` are
+passed, then the rotation matrix given by rotating in the span of `u` and `v` by
+angle `θ` is returned.
+"""
+function rotor(u::Vec{dim}, v::Vec{dim}, θ::Number) where {dim}
+    # See https://math.stackexchange.com/questions/197772/
+    # generalized-rotation-matrix-in-n-dimensional-space-around-n-2-unit-vector
+    one(Tensor{2, dim}) + sin(θ)*(otimes(v, u) - otimes(u, v)) + (cos(θ)-1)*(otimes(u) + otimes(v))
+end

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -358,10 +358,17 @@ end
 
 # http://inside.mines.edu/fs_home/gmurray/ArbitraryAxisRotation/
 """
-Rotate a tensor `x` around a vector `u` a total of `θ` radians.
+Rotate a tensor `x` around a vector `u` a total of `θ` radians. For an
+n-dimensional tensor `x`, rotate `x` a total of `θ` radians in the span
+defined by the orthonormal vectors `u` and `v`
 
 ```julia
 rotate(x::Vec{3}, u::Vec{3}, θ::Number)
+rotate(x::SecondOrderTensor{3}, u::Vec{3}, θ::Number)
+rotate(x::FourthOrderTensor{3}, u::Vec{3}, θ::Number)
+rotate(x::Vec{dim}, u::Vec{dim}, v::Vec{dim}, θ::Number)
+rotate(x::SecondOrderTensor{dim}, u::Vec{dim}, v::Vec{dim}, θ::Number)
+rotate(x::FourthOrderTensor{dim}, u::Vec{dim}, v::Vec{dim}, θ::Number)
 ```
 
 **Example:**
@@ -393,17 +400,23 @@ function rotate(x::Vec{3}, u::Vec{3}, θ::Number)
     s = sin(θ)
     (u * ux * (1 - c) + u² * x * c + sqrt(u²) * (u × x) * s) / u²
 end
+function rotate(x::SecondOrderTensor{3}, u::Vec{3}, θ::Number)
+    R = rotor(u, θ)
+    R ⋅ x ⋅ R'
+end
+function rotate(x::FourthOrderTensor{3}, u::Vec{3}, θ::Number)
+    R = rotor(u, θ)
+    R ⋅ R ⋅ x ⋅ R' ⋅ R'
+end
 
 function rotate(x::Vec{dim}, u::Vec{dim}, v::Vec{dim}, θ::Number) where {dim}
     R = rotor(u, v, θ)
     R ⋅ x
 end
-
 function rotate(x::SecondOrderTensor{dim}, u::Vec{dim}, v::Vec{dim}, θ::Number) where {dim}
     R = rotor(u, v, θ)
     R ⋅ x ⋅ R'
 end
-
 function rotate(x::FourthOrderTensor{dim}, u::Vec{dim}, v::Vec{dim}, θ::Number) where {dim}
     R = rotor(u, v, θ)
     R ⋅ R ⋅ x ⋅ R' ⋅ R'

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -358,7 +358,7 @@ end
 
 # http://inside.mines.edu/fs_home/gmurray/ArbitraryAxisRotation/
 """
-Rotate a three dimensional vector `x` around another vector `u` a total of `θ` radians.
+Rotate a tensor `x` around a vector `u` a total of `θ` radians.
 
 ```julia
 rotate(x::Vec{3}, u::Vec{3}, θ::Number)
@@ -394,3 +394,17 @@ function rotate(x::Vec{3}, u::Vec{3}, θ::Number)
     (u * ux * (1 - c) + u² * x * c + sqrt(u²) * (u × x) * s) / u²
 end
 
+function rotate(x::Vec{dim}, u::Vec{dim}, v::Vec{dim}, θ::Number) where {dim}
+    R = rotor(u, v, θ)
+    R ⋅ x
+end
+
+function rotate(x::SecondOrderTensor{dim}, u::Vec{dim}, v::Vec{dim}, θ::Number) where {dim}
+    R = rotor(u, v, θ)
+    R ⋅ x ⋅ R'
+end
+
+function rotate(x::FourthOrderTensor{dim}, u::Vec{dim}, v::Vec{dim}, θ::Number) where {dim}
+    R = rotor(u, v, θ)
+    R ⋅ R ⋅ x ⋅ R' ⋅ R'
+end

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -165,6 +165,8 @@ dot(::Vec, ::Vec)
 dot(::Vec, ::SecondOrderTensor)
 dot(::SecondOrderTensor, ::Vec)
 dot(::SecondOrderTensor, ::SecondOrderTensor)
+dot(::SecondOrderTensor, ::FourthOrderTensor)
+dot(::FourthOrderTensor, ::SecondOrderTensor)
 ```
 Computes the dot product (single contraction) between two tensors.
 The symbol `⋅`, written `\\cdot`, is overloaded for single contraction.
@@ -243,6 +245,36 @@ end
     quote
         $(Expr(:meta, :inline))
         @inbounds return Tensor{2, dim}($exps)
+    end
+end
+
+@generated function Base.dot(S1::FourthOrderTensor{dim}, S2::SecondOrderTensor{dim}) where {dim}
+    idxS1(i, j, k, l) = compute_index(get_base(S1), i, j, k, l)
+    idxS2(i, j) = compute_index(get_base(S2), i, j)
+    exps = Expr(:tuple)
+    for j in 1:dim, i in 1:dim, k in 1:dim, l in 1:dim
+        ex1 = Expr[:(get_data(S1)[$(idxS1(i, j, k, m))]) for m in 1:dim]
+        ex2 = Expr[:(get_data(S2)[$(idxS2(m, l))]) for m in 1:dim]
+        push!(exps.args, reducer(ex1, ex2))
+    end
+    quote
+        $(Expr(:meta, :inline))
+        @inbounds return Tensor{4, dim}($exps)
+    end
+end
+
+@generated function Base.dot(S1::SecondOrderTensor{dim}, S2::FourthOrderTensor{dim}) where {dim}
+    idxS1(i, j) = compute_index(get_base(S1), i, j)
+    idxS2(i, j, k, l) = compute_index(get_base(S2), i, j, k, l)
+    exps = Expr(:tuple)
+    for j in 1:dim, i in 1:dim, k in 1:dim, l in 1:dim
+        ex1 = Expr[:(get_data(S1)[$(idxS1(i, m))]) for m in 1:dim]
+        ex2 = Expr[:(get_data(S2)[$(idxS2(m, j, k, l))]) for m in 1:dim]
+        push!(exps.args, reducer(ex1, ex2))
+    end
+    quote
+        $(Expr(:meta, :inline))
+        @inbounds return Tensor{4, dim}($exps)
     end
 end
 

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -252,7 +252,7 @@ end
     idxS1(i, j, k, l) = compute_index(get_base(S1), i, j, k, l)
     idxS2(i, j) = compute_index(get_base(S2), i, j)
     exps = Expr(:tuple)
-    for j in 1:dim, i in 1:dim, k in 1:dim, l in 1:dim
+    for l in 1:dim, k in 1:dim, j in 1:dim, i in 1:dim
         ex1 = Expr[:(get_data(S1)[$(idxS1(i, j, k, m))]) for m in 1:dim]
         ex2 = Expr[:(get_data(S2)[$(idxS2(m, l))]) for m in 1:dim]
         push!(exps.args, reducer(ex1, ex2))
@@ -267,7 +267,7 @@ end
     idxS1(i, j) = compute_index(get_base(S1), i, j)
     idxS2(i, j, k, l) = compute_index(get_base(S2), i, j, k, l)
     exps = Expr(:tuple)
-    for j in 1:dim, i in 1:dim, k in 1:dim, l in 1:dim
+    for l in 1:dim, k in 1:dim, j in 1:dim, i in 1:dim
         ex1 = Expr[:(get_data(S1)[$(idxS1(i, m))]) for m in 1:dim]
         ex2 = Expr[:(get_data(S2)[$(idxS2(m, j, k, l))]) for m in 1:dim]
         push!(exps.args, reducer(ex1, ex2))

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -79,6 +79,15 @@ end # of testsection
     @test (@inferred tdot(A_sym))::SymmetricTensor{2, dim, T} ≈ dot(transpose(A_sym), A_sym)
     @test (@inferred dott(A))::SymmetricTensor{2, dim, T}     ≈ dot(A, transpose(A))
     @test (@inferred dott(A_sym))::SymmetricTensor{2, dim, T} ≈ dot(A_sym, transpose(A_sym))
+    # 2 - 4
+    @test (@inferred dot(AA, B))::Tensor{4, dim, T} ≈ reshape(collect(reshape(vec(AA), (dim^3, dim))) * collect(reshape(vec(B), (dim, dim))), (dim, dim, dim, dim))
+    @test (@inferred dot(B, AA))::Tensor{4, dim, T} ≈ reshape(collect(reshape(vec(B), (dim, dim))) * collect(reshape(vec(AA), (dim, dim^3))), (dim, dim, dim, dim))
+    @test (@inferred dot(AA_sym, B))::Tensor{4, dim, T} ≈ reshape(collect(reshape(vec(AA_sym), (dim^3, dim))) * collect(reshape(vec(B), (dim, dim))), (dim, dim, dim, dim))
+    @test (@inferred dot(B, AA_sym))::Tensor{4, dim, T} ≈ reshape(collect(reshape(vec(B), (dim, dim))) * collect(reshape(vec(AA_sym), (dim, dim^3))), (dim, dim, dim, dim))
+    @test (@inferred dot(AA, B_sym))::Tensor{4, dim, T} ≈ reshape(collect(reshape(vec(AA), (dim^3, dim))) * collect(reshape(vec(B_sym), (dim, dim))), (dim, dim, dim, dim))
+    @test (@inferred dot(B_sym, AA))::Tensor{4, dim, T} ≈ reshape(collect(reshape(vec(B_sym), (dim, dim))) * collect(reshape(vec(AA), (dim, dim^3))), (dim, dim, dim, dim))
+    @test (@inferred dot(AA_sym, B_sym))::Tensor{4, dim, T} ≈ reshape(collect(reshape(vec(AA_sym), (dim^3, dim))) * collect(reshape(vec(B_sym), (dim, dim))), (dim, dim, dim, dim))
+    @test (@inferred dot(B_sym, AA_sym))::Tensor{4, dim, T} ≈ reshape(collect(reshape(vec(B_sym), (dim, dim))) * collect(reshape(vec(AA_sym), (dim, dim^3))), (dim, dim, dim, dim))
 end # of testsection
 
 @testsection "symmetric/skew-symmetric" begin
@@ -193,6 +202,36 @@ if dim == 3
         @test rotate(a, b, 0) ≈ a
         @test rotate(a, b, π) ≈ rotate(a, b, -π)
         @test rotate(a, b, π/2) ≈ rotate(a, -b, -π/2)
+
+        # test vector-span definition
+        @test rotate(x, y, π/2) ≈ rotate(x, z, x, π/2)
+        @test rotate(2*z, z, x, π/2) ≈ 2*x
+        @test rotate(a, a, b, 0) ≈ a
+        @test rotate(a, a, b, π) ≈ rotate(a, a, b, -π)
+        @test rotate(a, a, b, π/2) ≈ rotate(a, b, a, -π/2)
+
+        # test second-order tensor rotations
+        A = rand(Tensor{2, 3})
+        @test rotate(A, x, π) ≈ rotate(A, x, -π)
+        @test rotate(rotate(rotate(A, x, π), y, π), z, π) ≈ A
+        @test rotate(A, a, 0) ≈ A
+        @test rotate(A, a, π/2) ≈ rotate(A, -a, -π/2)
+
+        @test rotate(A, a, b, 0) ≈ A
+        @test rotate(A, a, b, π) ≈ rotate(A, a, b, -π)
+        @test rotate(A, a, b, π/2) ≈ rotate(A, b, a, -π/2)
+
+        # test fourth-order tensor rotations
+        A = rand(Tensor{4, 3})
+        @test rotate(A, x, π) ≈ rotate(A, x, -π)
+        @test rotate(rotate(rotate(A, x, π), y, π), z, π) ≈ A
+        @test rotate(A, a, 0) ≈ A
+        @test rotate(A, a, π/2) ≈ rotate(A, -a, -π/2)
+
+        @test rotate(A, a, b, 0) ≈ A
+        @test rotate(A, a, b, π) ≈ rotate(A, a, b, -π)
+        @test rotate(A, a, b, π/2) ≈ rotate(A, b, a, -π/2)
+
     end
 end
 


### PR DESCRIPTION
Added the following:

* Rotations for 2/4 order tensors in 3 dimensions (`rotate(x, u, angle)`)
* Generic rotations for 1/2/4 order tensors in n-dimensions (`rotate(x, u, v, angle)`). For this `u` and `v` are orthonormal vectors which define the n-2 dimensional space the rotation occurs in.
* Tests for 2-4 tensor dot product
* Tests for rotations in three dimensions

I tested out a generic fallback constructor which allowed n-dimensional tensors, but I may have been getting some test errors from that definition, or at least I wasn't sure where they were coming from. I'll look for a safer way to define such a constructor for a future PR.