### PR TITLE
Add some constructors for heterogeneous tuples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tensors"
 uuid = "48a634ad-e948-5137-8d70-aa71f2a747f4"
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -57,6 +57,16 @@ end
     end
 end
 
+# Tensor from heterogeneous Tuple
+function Tensor{order, dim}(data::Tuple) where {order, dim}
+    return Tensor{order,dim}(promote(data...))
+end
+
+# SymmetricTensor from heterogeneous Tuple
+function SymmetricTensor{order, dim}(data::Tuple) where {order, dim}
+    return SymmetricTensor{order,dim}(promote(data...))
+end
+
 # one (identity tensor)
 for TensorType in (SymmetricTensor, Tensor)
     @eval begin

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -37,6 +37,27 @@ for T in (Float32, Float64, F64), dim in (1,2,3), order in (1,2,4)
         @test eltype(tens_arr2) == eltype(tens_arr3) == TensorType{order, dim, T, N}
     end
 end
+for dim in (1, 2, 3)
+    # Heterogeneous tuple/type unstable function
+    z(i, jkl...) = i % 2 == 0 ? 0 : float(0)
+    @test Vec{dim}(ntuple(z, dim))::Vec{dim,Float64} ==
+          Vec{dim}(z)::Vec{dim,Float64}
+    # @test Vec{dim,Float32}(ntuple(z, dim))::Vec{dim,Float32} ==
+    #       Vec{dim,Float32}(z)::Vec{dim,Float32}
+    for order in (1, 2, 4)
+        N = Tensors.n_components(Tensor{order,dim})
+        @test Tensor{order,dim}(ntuple(z, N))::Tensor{order,dim,Float64} ==
+              Tensor{order,dim}(z)::Tensor{order,dim,Float64}
+        @test Tensor{order,dim,Float32}(ntuple(z, N))::Tensor{order,dim,Float32} ==
+              Tensor{order,dim,Float32}(z)::Tensor{order,dim,Float32}
+        order == 1 && continue
+        N = Tensors.n_components(SymmetricTensor{order,dim})
+        @test SymmetricTensor{order,dim}(ntuple(z, N))::SymmetricTensor{order,dim,Float64} ==
+              SymmetricTensor{order,dim}(z)::SymmetricTensor{order,dim,Float64}
+        @test SymmetricTensor{order,dim,Float32}(ntuple(z, N))::SymmetricTensor{order,dim,Float32} ==
+              SymmetricTensor{order,dim,Float32}(z)::SymmetricTensor{order,dim,Float32}
+    end
+end
 end # of testset
 
 @testsection "diagm, one" begin


### PR DESCRIPTION
Fixes e.g. these cases:
```julia
julia> S = Tensor{2,2}((1, 2, 3, 4));

julia> dev(S)
2×2 Tensor{2,2,Float64,4}:
 -0.666667  3.0    
  2.0       2.33333

julia> fromvoigt(SymmetricTensor{2,2}, [1,1,1])
2×2 SymmetricTensor{2,2,Float64,3}:
 1.0  1.0
 1.0  1.0

julia> Tensor{2,2}((true, 2, 3.0, Float32(4)))
2×2 Tensor{2,2,Float64,4}:
 1.0  3.0
 2.0  4.0
```
So now you can use integer tensors @KimAuth :stuck_out_tongue: 