### PR TITLE
Use Tuple instead of get_data

### DIFF
--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -88,7 +88,7 @@ const NonSymmetricTensors{dim, T} = Union{Tensor{2, dim, T}, Tensor{4, dim, T}, 
 ##############################
 # Utility/Accessor Functions #
 ##############################
-get_data(t::AbstractTensor) = t.data
+Base.Tuple(t::AbstractTensor) = t.data
 
 @pure n_components(::Type{SymmetricTensor{2, dim}}) where {dim} = dim*dim - div((dim-1)*dim, 2)
 @pure function n_components(::Type{SymmetricTensor{4, dim}}) where {dim}

--- a/src/automatic_differentiation.jl
+++ b/src/automatic_differentiation.jl
@@ -30,7 +30,7 @@ end
     for i in 1:n_components(TensorType)
         # Can use linear indexing even for SymmetricTensor
         # when indexing the underlying tuple
-        push!(ex.args, :(value(get_data(v)[$i])))
+        push!(ex.args, :(value(Tuple(v)[$i])))
     end
     quote
         $(Expr(:meta, :inline))
@@ -53,7 +53,7 @@ end
     for i in 1:n_components(TensorType)
         # Can use linear indexing even for SymmetricTensor
         # when indexing the underlying tuple
-        push!(ex.args, :(partials(get_data(v)[$i])[1]))
+        push!(ex.args, :(partials(Tuple(v)[$i])[1]))
     end
     quote
         $(Expr(:meta, :inline))
@@ -221,17 +221,17 @@ end
 
 # Second order tensors
 @inline function _load(v::Tensor{2, 1, T}) where {T}
-    @inbounds v_dual = Tensor{2, 1}((Dual(get_data(v)[1], one(T)),))
+    @inbounds v_dual = Tensor{2, 1}((Dual(Tuple(v)[1], one(T)),))
     return v_dual
 end
 
 @inline function _load(v::SymmetricTensor{2, 1, T}) where {T}
-    @inbounds v_dual = SymmetricTensor{2, 1}((Dual(get_data(v)[1], one(T)),))
+    @inbounds v_dual = SymmetricTensor{2, 1}((Dual(Tuple(v)[1], one(T)),))
     return v_dual
 end
 
 @inline function _load(v::Tensor{2, 2, T}) where {T}
-    data = get_data(v)
+    data = Tuple(v)
     o = one(T)
     z = zero(T)
     @inbounds v_dual = Tensor{2, 2}((Dual(data[1], o, z, z, z),
@@ -242,7 +242,7 @@ end
 end
 
 @inline function _load(v::SymmetricTensor{2, 2, T}) where {T}
-    data = get_data(v)
+    data = Tuple(v)
     o = one(T)
     o2 = convert(T, 1/2)
     z = zero(T)
@@ -253,7 +253,7 @@ end
 end
 
 @inline function _load(v::Tensor{2, 3, T}) where {T}
-    data = get_data(v)
+    data = Tuple(v)
     o = one(T)
     z = zero(T)
     @inbounds v_dual = Tensor{2, 3}((Dual(data[1], o, z, z, z, z, z, z, z, z),
@@ -269,7 +269,7 @@ end
 end
 
 @inline function _load(v::SymmetricTensor{2, 3, T}) where {T}
-    data = get_data(v)
+    data = Tuple(v)
     o = one(T)
     o2 = convert(T, 1/2)
     z = zero(T)

--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -52,8 +52,8 @@ end
     idxS2(i, j) = compute_index(get_base(S2), i, j)
     exps = Expr(:tuple)
     for j in 1:dim, i in j:dim
-        ex1 = Expr[:(get_data(S1)[$(idxS1(i, k))]) for k in 1:dim]
-        ex2 = Expr[:(get_data(S2)[$(idxS2(k, j))]) for k in 1:dim]
+        ex1 = Expr[:(Tuple(S1)[$(idxS1(i, k))]) for k in 1:dim]
+        ex2 = Expr[:(Tuple(S2)[$(idxS2(k, j))]) for k in 1:dim]
         push!(exps.args, reducer(ex1, ex2))
     end
     quote

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -43,19 +43,19 @@ const SYMMETRIC_INDICES = ((), ([1,], [1, 2, 4], [1, 2, 3, 5, 6, 9]), (),
 ###########################
 @inline function Base.getindex(S::Tensor, i::Int)
     @boundscheck checkbounds(S, i)
-    @inbounds v = get_data(S)[i]
+    @inbounds v = Tuple(S)[i]
     return v
 end
 
 @inline function Base.getindex(S::SymmetricTensor{2, dim}, i::Int, j::Int) where {dim}
     @boundscheck checkbounds(S, i, j)
-    @inbounds v = get_data(S)[compute_index(SymmetricTensor{2, dim}, i, j)]
+    @inbounds v = Tuple(S)[compute_index(SymmetricTensor{2, dim}, i, j)]
     return v
 end
 
 @inline function Base.getindex(S::SymmetricTensor{4, dim}, i::Int, j::Int, k::Int, l::Int) where {dim}
     @boundscheck checkbounds(S, i, j, k, l)
-    @inbounds v = get_data(S)[compute_index(SymmetricTensor{4, dim}, i, j, k, l)]
+    @inbounds v = Tuple(S)[compute_index(SymmetricTensor{4, dim}, i, j, k, l)]
     return v
 end
 
@@ -68,9 +68,9 @@ end
 
 @inline @generated function Base.getindex(S::SecondOrderTensor{dim}, ::Colon, j::Int) where {dim}
     idx2(i,j) = compute_index(get_base(S), i, j)
-    ex1 = Expr(:tuple, [:(get_data(S)[$(idx2(i,1))]) for i in 1:dim]...)
-    ex2 = Expr(:tuple, [:(get_data(S)[$(idx2(i,2))]) for i in 1:dim]...)
-    ex3 = Expr(:tuple, [:(get_data(S)[$(idx2(i,3))]) for i in 1:dim]...)
+    ex1 = Expr(:tuple, [:(Tuple(S)[$(idx2(i,1))]) for i in 1:dim]...)
+    ex2 = Expr(:tuple, [:(Tuple(S)[$(idx2(i,2))]) for i in 1:dim]...)
+    ex3 = Expr(:tuple, [:(Tuple(S)[$(idx2(i,3))]) for i in 1:dim]...)
     return quote
         @boundscheck checkbounds(S,Colon(),j)
         if     j == 1 return Vec{dim}($ex1)
@@ -81,9 +81,9 @@ end
 end
 @inline @generated function Base.getindex(S::SecondOrderTensor{dim}, i::Int, ::Colon) where {dim}
     idx2(i,j) = compute_index(get_base(S), i, j)
-    ex1 = Expr(:tuple, [:(get_data(S)[$(idx2(1,j))]) for j in 1:dim]...)
-    ex2 = Expr(:tuple, [:(get_data(S)[$(idx2(2,j))]) for j in 1:dim]...)
-    ex3 = Expr(:tuple, [:(get_data(S)[$(idx2(3,j))]) for j in 1:dim]...)
+    ex1 = Expr(:tuple, [:(Tuple(S)[$(idx2(1,j))]) for j in 1:dim]...)
+    ex2 = Expr(:tuple, [:(Tuple(S)[$(idx2(2,j))]) for j in 1:dim]...)
+    ex3 = Expr(:tuple, [:(Tuple(S)[$(idx2(3,j))]) for j in 1:dim]...)
     return quote
         @boundscheck checkbounds(S,i,Colon())
         if     i == 1 return Vec{dim}($ex1)

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -28,7 +28,7 @@ julia> norm(A)
     idx(i,j,k,l) = compute_index(get_base(S), i, j, k, l)
     ex = Expr[]
     for l in 1:dim, k in 1:dim, j in 1:dim, i in 1:dim
-        push!(ex, :(get_data(S)[$(idx(i,j,k,l))]))
+        push!(ex, :(Tuple(S)[$(idx(i,j,k,l))]))
     end
     exp = reducer(ex, ex)
     return quote
@@ -89,13 +89,13 @@ julia> inv(A)
         ex = :($Tt((dinv, )))
     elseif dim == 2
         ex = quote
-            v = get_data(t)
+            v = Tuple(t)
             $Tt((v[$(idx(2,2))] * dinv, -v[$(idx(2,1))] * dinv,
                 -v[$(idx(1,2))] * dinv,  v[$(idx(1,1))] * dinv))
         end
     else # dim == 3
         ex = quote
-            v = get_data(t)
+            v = Tuple(t)
             $Tt(((v[$(idx(2,2))]*v[$(idx(3,3))] - v[$(idx(2,3))]*v[$(idx(3,2))]) * dinv,
                 -(v[$(idx(2,1))]*v[$(idx(3,3))] - v[$(idx(2,3))]*v[$(idx(3,1))]) * dinv,
                  (v[$(idx(2,1))]*v[$(idx(3,2))] - v[$(idx(2,2))]*v[$(idx(3,1))]) * dinv,
@@ -123,13 +123,13 @@ end
         ex = :($Tt((dinv, )))
     elseif dim == 2
         ex = quote
-            v = get_data(t)
+            v = Tuple(t)
             $Tt((v[$(idx(2,2))] * dinv, -v[$(idx(2,1))] * dinv,
                  v[$(idx(1,1))] * dinv))
         end
     else # dim == 3
         ex = quote
-            v = get_data(t)
+            v = Tuple(t)
             $Tt(((v[$(idx(2,2))]*v[$(idx(3,3))] - v[$(idx(2,3))]*v[$(idx(3,2))]) * dinv,
                 -(v[$(idx(2,1))]*v[$(idx(3,3))] - v[$(idx(2,3))]*v[$(idx(3,1))]) * dinv,
                  (v[$(idx(2,1))]*v[$(idx(3,2))] - v[$(idx(2,2))]*v[$(idx(3,1))]) * dinv,
@@ -311,7 +311,7 @@ julia> tr(A)
 """
 @generated function LinearAlgebra.tr(S::SecondOrderTensor{dim}) where {dim}
     idx(i,j) = compute_index(get_base(S), i, j)
-    ex = Expr[:(get_data(S)[$(idx(i,i))]) for i in 1:dim]
+    ex = Expr[:(Tuple(S)[$(idx(i,i))]) for i in 1:dim]
     exp = reduce((ex1, ex2) -> :(+($ex1, $ex2)), ex)
     @inbounds return exp
 end

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -93,8 +93,8 @@ end
 ################################
 @inline function Base.:+(S1::TT, S2::TT) where {TT <: AllSIMDTensors}
     @inbounds begin
-        D1 = get_data(S1); SV1 = tosimd(D1)
-        D2 = get_data(S2); SV2 = tosimd(D2)
+        D1 = Tuple(S1); SV1 = tosimd(D1)
+        D2 = Tuple(S2); SV2 = tosimd(D2)
         r = SV1 + SV2
         return get_base(TT)(r)
     end
@@ -103,8 +103,8 @@ end
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
-            D1 = get_data(S1); SV180 = tosimd(D1, Val{1}, Val{80})
-            D2 = get_data(S2); SV280 = tosimd(D2, Val{1}, Val{80})
+            D1 = Tuple(S1); SV180 = tosimd(D1, Val{1}, Val{80})
+            D2 = Tuple(S2); SV280 = tosimd(D2, Val{1}, Val{80})
             r = SV180 + SV280
             r81 = D1[81] + D2[81]
             return Tensor{4, 3}($(Expr(:tuple, [:(r[$i]) for i in 1:80]..., :(r81))))
@@ -113,8 +113,8 @@ end
 end
 @inline function Base.:-(S1::TT, S2::TT) where {TT <: AllSIMDTensors}
     @inbounds begin
-        D1 = get_data(S1); SV1 = tosimd(D1)
-        D2 = get_data(S2); SV2 = tosimd(D2)
+        D1 = Tuple(S1); SV1 = tosimd(D1)
+        D2 = Tuple(S2); SV2 = tosimd(D2)
         r = SV1 - SV2
         return get_base(TT)(r)
     end
@@ -123,8 +123,8 @@ end
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
-            D1 = get_data(S1); SV180 = tosimd(D1, Val{1}, Val{80})
-            D2 = get_data(S2); SV280 = tosimd(D2, Val{1}, Val{80})
+            D1 = Tuple(S1); SV180 = tosimd(D1, Val{1}, Val{80})
+            D2 = Tuple(S2); SV280 = tosimd(D2, Val{1}, Val{80})
             r = SV180 - SV280
             r81 = D1[81] - D2[81]
             return Tensor{4, 3}($(Expr(:tuple, [:(r[$i]) for i in 1:80]..., :(r81))))
@@ -137,21 +137,21 @@ end
 ##########################################
 @inline function Base.:*(n::T, S::AllSIMDTensors{T}) where {T <: SIMDTypes}
     @inbounds begin
-        D = get_data(S); SV = tosimd(D)
+        D = Tuple(S); SV = tosimd(D)
         r = n * SV
         return get_base(typeof(S))(r)
     end
 end
 @inline function Base.:*(S::AllSIMDTensors{T}, n::T) where {T <: SIMDTypes}
     @inbounds begin
-        D = get_data(S); SV = tosimd(D)
+        D = Tuple(S); SV = tosimd(D)
         r = SV * n
         return get_base(typeof(S))(r)
     end
 end
 @inline function Base.:/(S::AllSIMDTensors{T}, n::T) where {T <: SIMDTypes}
     @inbounds begin
-        D = get_data(S); SV = tosimd(D)
+        D = Tuple(S); SV = tosimd(D)
         r = SV / n
         return get_base(typeof(S))(r)
     end
@@ -160,7 +160,7 @@ end
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
-            D = get_data(S); SV80 = tosimd(D, Val{1}, Val{80})
+            D = Tuple(S); SV80 = tosimd(D, Val{1}, Val{80})
             r = n * SV80; r81 = n * D[81]
             return Tensor{4, 3}($(Expr(:tuple, [:(r[$i]) for i in 1:80]..., :(r81))))
         end
@@ -170,7 +170,7 @@ end
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
-            D = get_data(S); SV80 = tosimd(D, Val{1}, Val{80})
+            D = Tuple(S); SV80 = tosimd(D, Val{1}, Val{80})
             r = SV80 * n; r81 = D[81] * n
             return Tensor{4, 3}($(Expr(:tuple, [:(r[$i]) for i in 1:80]..., :(r81))))
         end
@@ -180,7 +180,7 @@ end
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
-            D = get_data(S); SV80 = tosimd(D, Val{1}, Val{80})
+            D = Tuple(S); SV80 = tosimd(D, Val{1}, Val{80})
             r = SV80 / n; r81 = D[81] / n
             return Tensor{4, 3}($(Expr(:tuple, [:(r[$i]) for i in 1:80]..., :(r81))))
         end
@@ -195,7 +195,7 @@ end
 # 2-1
 @inline function LinearAlgebra.dot(S1::Tensor{2, 2, T}, S2::Vec{2, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1}, Val{2})
         SV12 = tosimd(D1, Val{3}, Val{4})
         r = muladd(SV12, D2[2], SV11 * D2[1])
@@ -204,7 +204,7 @@ end
 end
 @inline function LinearAlgebra.dot(S1::Tensor{2, 3, T}, S2::Vec{3, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1}, Val{3})
         SV12 = tosimd(D1, Val{4}, Val{6})
         SV13 = tosimd(D1, Val{7}, Val{9})
@@ -220,7 +220,7 @@ end
 # 2-2
 @inline function LinearAlgebra.dot(S1::Tensor{2, 2, T}, S2::Tensor{2, 2, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1}, Val{2})
         SV12 = tosimd(D1, Val{3}, Val{4})
         r1 = muladd(SV12, D2[2], SV11 * D2[1])
@@ -230,7 +230,7 @@ end
 end
 @inline function LinearAlgebra.dot(S1::Tensor{2, 3, T}, S2::Tensor{2, 3, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1}, Val{3})
         SV12 = tosimd(D1, Val{4}, Val{6})
         SV13 = tosimd(D1, Val{7}, Val{9})
@@ -250,8 +250,8 @@ end
 end
 # 2-2
 @inline function dcontract(S1::Tensor{2, dim, T}, S2::Tensor{2, dim, T}) where {dim, T <: SIMDTypes}
-    SV1 = tosimd(get_data(S1))
-    SV2 = tosimd(get_data(S2))
+    SV1 = tosimd(Tuple(S1))
+    SV2 = tosimd(Tuple(S2))
     r = SV1 * SV2
     return sum(r)
 end
@@ -261,8 +261,8 @@ end
     return quote
         $(Expr(:meta, :inline))
         F = $F
-        SV1 = tosimd(get_data(S1))
-        SV2 = tosimd(get_data(S2))
+        SV1 = tosimd(Tuple(S1))
+        SV2 = tosimd(Tuple(S2))
         SV1SV2 = SV1 * SV2; FSV1SV2 = F * SV1SV2
         return sum(FSV1SV2)
     end
@@ -273,7 +273,7 @@ end
 # 4-2
 @inline function dcontract(S1::Tensor{4, 2, T}, S2::Tensor{2, 2, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1}, Val{4})
         SV12 = tosimd(D1, Val{5}, Val{8})
         SV13 = tosimd(D1, Val{9}, Val{12})
@@ -284,7 +284,7 @@ end
 end
 @inline function dcontract(S1::Tensor{4, 3, T}, S2::Tensor{2, 3, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1},  Val{9})
         SV12 = tosimd(D1, Val{10}, Val{18})
         SV13 = tosimd(D1, Val{19}, Val{27})
@@ -300,7 +300,7 @@ end
 end
 @inline function dcontract(S1::SymmetricTensor{4, 3, T}, S2::SymmetricTensor{2, 3, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1},  Val{6})
         SV12 = tosimd(D1, Val{7},  Val{12})
         SV13 = tosimd(D1, Val{13}, Val{18})
@@ -321,7 +321,7 @@ end
 # 4-4
 @inline function dcontract(S1::Tensor{4, 2, T}, S2::Tensor{4, 2, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1},  Val{4})
         SV12 = tosimd(D1, Val{5},  Val{8})
         SV13 = tosimd(D1, Val{9},  Val{12})
@@ -335,7 +335,7 @@ end
 end
 function dcontract(S1::Tensor{4, 3, T}, S2::Tensor{4, 3, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1},  Val{9})
         SV12 = tosimd(D1, Val{10}, Val{18})
         SV13 = tosimd(D1, Val{19}, Val{27})
@@ -359,7 +359,7 @@ function dcontract(S1::Tensor{4, 3, T}, S2::Tensor{4, 3, T}) where {T <: SIMDTyp
 end
 @inline function dcontract(S1::SymmetricTensor{4, 3, T}, S2::Tensor{2, 3, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1},  Val{6})
         SV12 = tosimd(D1, Val{7}, Val{12})
         SV13 = tosimd(D1, Val{13}, Val{18})
@@ -374,7 +374,7 @@ end
 end
 @inline function dcontract(S1::SymmetricTensor{4, 2, T}, S2::SymmetricTensor{4, 2, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1},  Val{3})
         SV12 = tosimd(D1, Val{4},  Val{6})
         SV13 = tosimd(D1, Val{7},  Val{9})
@@ -389,7 +389,7 @@ end
 end
 function dcontract(S1::SymmetricTensor{4, 3, T}, S2::SymmetricTensor{4, 3, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV11 = tosimd(D1, Val{1},  Val{6})
         SV12 = tosimd(D1, Val{7},  Val{12})
         SV13 = tosimd(D1, Val{13}, Val{18})
@@ -418,7 +418,7 @@ end
 # 1-1
 @inline function otimes(S1::Vec{2, T}, S2::Vec{2, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV1 = tosimd(D1)
         r1 = SV1 * D2[1]
         r2 = SV1 * D2[2]
@@ -427,7 +427,7 @@ end
 end
 @inline function otimes(S1::Vec{3, T}, S2::Vec{3, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV1 = tosimd(D1)
         r1 = SV1 * D2[1]; r2 = SV1 * D2[2]; r3 = SV1 * D2[3]
         return Tensor{2, 3}((r1, r2, r3))
@@ -442,7 +442,7 @@ end
 # 2-2
 @inline function otimes(S1::Tensor{2, 2, T}, S2::Tensor{2, 2, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV1 = tosimd(D1)
         r1 = SV1 * D2[1]; r2 = SV1 * D2[2]; r3 = SV1 * D2[3]; r4 = SV1 * D2[4]
         return Tensor{4, 2}((r1, r2, r3, r4))
@@ -450,7 +450,7 @@ end
 end
 @inline function otimes(S1::Tensor{2, 3, T}, S2::Tensor{2, 3, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV1 = tosimd(D1)
         r1 = SV1 * D2[1]; r2 = SV1 * D2[2]; r3 = SV1 * D2[3]
         r4 = SV1 * D2[4]; r5 = SV1 * D2[5]; r6 = SV1 * D2[6]
@@ -462,7 +462,7 @@ end
 # 2s-2s
 @inline function otimes(S1::SymmetricTensor{2, 2, T}, S2::SymmetricTensor{2, 2, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV1 = tosimd(D1)
         r1 = SV1 * D2[1]; r2 = SV1 * D2[2]; r3 = SV1 * D2[3]
         return SymmetricTensor{4, 2}((r1, r2, r3))
@@ -470,7 +470,7 @@ end
 end
 @inline function otimes(S1::SymmetricTensor{2, 3, T}, S2::SymmetricTensor{2, 3, T}) where {T <: SIMDTypes}
     @inbounds begin
-        D1 = get_data(S1); D2 = get_data(S2)
+        D1 = Tuple(S1); D2 = Tuple(S2)
         SV1 = tosimd(D1)
         r1 = SV1 * D2[1]; r2 = SV1 * D2[2]; r3 = SV1 * D2[3]
         r4 = SV1 * D2[4]; r5 = SV1 * D2[5]; r6 = SV1 * D2[6]
@@ -484,7 +484,7 @@ end
 # order 1 and order 2 norms rely on dot and dcontract respectively
 @inline function LinearAlgebra.norm(S::Tensor{4, 2, T}) where {T <: SIMDTypes}
     @inbounds begin
-        SV = tosimd(get_data(S))
+        SV = tosimd(Tuple(S))
         SVSV = SV * SV
         r = sum(SVSV)
         return sqrt(r)
@@ -494,7 +494,7 @@ end
     return quote
         $(Expr(:meta, :inline))
         @inbounds begin
-            D = get_data(S)
+            D = Tuple(S)
             SV80 = tosimd(D, Val{1}, Val{80})
             SV80SV80 = SV80 * SV80
             r80 = sum(SV80SV80)
@@ -508,7 +508,7 @@ end
     return quote
         $(Expr(:meta, :inline))
         F = $F
-        SV = tosimd(get_data(S))
+        SV = tosimd(Tuple(S))
         SVSV = SV * SV; FSVSV = F * SVSV; r = sum(FSVSV)
         return sqrt(r)
     end

--- a/src/special_ops.jl
+++ b/src/special_ops.jl
@@ -11,8 +11,8 @@ such that ``a_k C_{ikjl} b_l``.
     for j in 1:dim, i in 1:dim
         ex1, ex2 = Expr[],Expr[]
         for l in 1:dim, k in 1:dim
-            push!(ex1, :(get_data(v1)[$k] * get_data(S)[$(idx(i,k,j,l))]))
-            push!(ex2, :(get_data(v2)[$l]))
+            push!(ex1, :(Tuple(v1)[$k] * Tuple(S)[$(idx(i,k,j,l))]))
+            push!(ex2, :(Tuple(v2)[$l]))
         end
         push!(exps.args, reducer(ex1, ex2, true))
     end

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -25,8 +25,8 @@ julia> A ⊡ B
 @generated function dcontract(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim}) where {dim}
     idxS1(i, j) = compute_index(get_base(S1), i, j)
     idxS2(i, j) = compute_index(get_base(S2), i, j)
-    ex1 = Expr[:(get_data(S1)[$(idxS1(i, j))]) for i in 1:dim, j in 1:dim][:]
-    ex2 = Expr[:(get_data(S2)[$(idxS2(i, j))]) for i in 1:dim, j in 1:dim][:]
+    ex1 = Expr[:(Tuple(S1)[$(idxS1(i, j))]) for i in 1:dim, j in 1:dim][:]
+    ex2 = Expr[:(Tuple(S2)[$(idxS2(i, j))]) for i in 1:dim, j in 1:dim][:]
     exp = reducer(ex1, ex2)
     return quote
         $(Expr(:meta, :inline))
@@ -40,8 +40,8 @@ end
     idxS2(i, j, k, l) = compute_index(get_base(S2), i, j, k, l)
     exps = Expr(:tuple)
     for l in 1:dim, k in 1:dim
-        ex1 = Expr[:(get_data(S1)[$(idxS1(i, j))])       for i in 1:dim, j in 1:dim][:]
-        ex2 = Expr[:(get_data(S2)[$(idxS2(i, j, k, l))]) for i in 1:dim, j in 1:dim][:]
+        ex1 = Expr[:(Tuple(S1)[$(idxS1(i, j))])       for i in 1:dim, j in 1:dim][:]
+        ex2 = Expr[:(Tuple(S2)[$(idxS2(i, j, k, l))]) for i in 1:dim, j in 1:dim][:]
         push!(exps.args, reducer(ex1, ex2, true))
     end
     expr = remove_duplicates(TensorType, exps)
@@ -57,8 +57,8 @@ end
     idxS2(i, j) = compute_index(get_base(S2), i, j)
     exps = Expr(:tuple)
     for j in 1:dim, i in 1:dim
-        ex1 = Expr[:(get_data(S1)[$(idxS1(i, j, k, l))]) for k in 1:dim, l in 1:dim][:]
-        ex2 = Expr[:(get_data(S2)[$(idxS2(k, l))])       for k in 1:dim, l in 1:dim][:]
+        ex1 = Expr[:(Tuple(S1)[$(idxS1(i, j, k, l))]) for k in 1:dim, l in 1:dim][:]
+        ex2 = Expr[:(Tuple(S2)[$(idxS2(k, l))])       for k in 1:dim, l in 1:dim][:]
         push!(exps.args, reducer(ex1, ex2, true))
     end
     expr = remove_duplicates(TensorType, exps)
@@ -74,8 +74,8 @@ end
     idxS2(i, j, k, l) = compute_index(get_base(S2), i, j, k, l)
     exps = Expr(:tuple)
     for l in 1:dim, k in 1:dim, j in 1:dim, i in 1:dim
-        ex1 = Expr[:(get_data(S1)[$(idxS1(i, j, m, n))]) for m in 1:dim, n in 1:dim][:]
-        ex2 = Expr[:(get_data(S2)[$(idxS2(m, n, k, l))]) for m in 1:dim, n in 1:dim][:]
+        ex1 = Expr[:(Tuple(S1)[$(idxS1(i, j, m, n))]) for m in 1:dim, n in 1:dim][:]
+        ex2 = Expr[:(Tuple(S2)[$(idxS2(m, n, k, l))]) for m in 1:dim, n in 1:dim][:]
         push!(exps.args, reducer(ex1, ex2, true))
     end
     expr = remove_duplicates(TensorType, exps)
@@ -254,8 +254,8 @@ julia> A ⋅ B
 ```
 """
 @generated function LinearAlgebra.dot(S1::Vec{dim}, S2::Vec{dim}) where {dim}
-    ex1 = Expr[:(get_data(S1)[$i]) for i in 1:dim]
-    ex2 = Expr[:(get_data(S2)[$i]) for i in 1:dim]
+    ex1 = Expr[:(Tuple(S1)[$i]) for i in 1:dim]
+    ex2 = Expr[:(Tuple(S2)[$i]) for i in 1:dim]
     exp = reducer(ex1, ex2)
     quote
         $(Expr(:meta, :inline))
@@ -267,8 +267,8 @@ end
     idxS1(i, j) = compute_index(get_base(S1), i, j)
     exps = Expr(:tuple)
     for i in 1:dim
-        ex1 = Expr[:(get_data(S1)[$(idxS1(i, j))]) for j in 1:dim]
-        ex2 = Expr[:(get_data(S2)[$j])             for j in 1:dim]
+        ex1 = Expr[:(Tuple(S1)[$(idxS1(i, j))]) for j in 1:dim]
+        ex2 = Expr[:(Tuple(S2)[$j])             for j in 1:dim]
         push!(exps.args, reducer(ex1, ex2))
     end
     quote
@@ -281,8 +281,8 @@ end
     idxS2(i, j) = compute_index(get_base(S2), i, j)
     exps = Expr(:tuple)
     for j in 1:dim
-        ex1 = Expr[:(get_data(S1)[$i])             for i in 1:dim]
-        ex2 = Expr[:(get_data(S2)[$(idxS2(i, j))]) for i in 1:dim]
+        ex1 = Expr[:(Tuple(S1)[$i])             for i in 1:dim]
+        ex2 = Expr[:(Tuple(S2)[$(idxS2(i, j))]) for i in 1:dim]
         push!(exps.args, reducer(ex1, ex2))
     end
     quote
@@ -296,8 +296,8 @@ end
     idxS2(i, j) = compute_index(get_base(S2), i, j)
     exps = Expr(:tuple)
     for j in 1:dim, i in 1:dim
-        ex1 = Expr[:(get_data(S1)[$(idxS1(i, k))]) for k in 1:dim]
-        ex2 = Expr[:(get_data(S2)[$(idxS2(k, j))]) for k in 1:dim]
+        ex1 = Expr[:(Tuple(S1)[$(idxS1(i, k))]) for k in 1:dim]
+        ex2 = Expr[:(Tuple(S2)[$(idxS2(k, j))]) for k in 1:dim]
         push!(exps.args, reducer(ex1, ex2))
     end
     quote
@@ -354,8 +354,8 @@ julia> tdot(A)
     idxS(i,j) = compute_index(get_base(S), i, j)
     ex = Expr(:tuple)
     for j in 1:dim, i in 1:dim
-        ex1 = Expr[:(get_data(S)[$(idxS(k, i))]) for k in 1:dim]
-        ex2 = Expr[:(get_data(S)[$(idxS(k, j))]) for k in 1:dim]
+        ex1 = Expr[:(Tuple(S)[$(idxS(k, i))]) for k in 1:dim]
+        ex2 = Expr[:(Tuple(S)[$(idxS(k, j))]) for k in 1:dim]
         push!(ex.args, reducer(ex1, ex2))
     end
     expr = remove_duplicates(SymmetricTensor{2, dim}, ex)


### PR DESCRIPTION
This PR is for easily getting tuple data from tensors.

Sometimes I need to use both of `Tensors` and `StaticArrays` packages because `Tensors` doesn't support non-square matrix. In this case, I need to write `Tensors.get_data` to get the tuple. But, I thought that it might be better to define `Tuple` instead of `get_data` as used in `StaticArrays`.

I think there is no confusion because we already have documentation to construct tensors from tuples. This is just reverse method for it. What do you think?

I know I can just define it by myself after `using Tensors`, but it is useful if we have it :)