### PR TITLE
Add pseudo-inverse of tensors and enable tranpose for Vec{dim}

### DIFF
--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -72,7 +72,7 @@ end
 ###############
 # Typealiases #
 ###############
-const Vec{dim, T, M} = Tensor{1, dim, T, dim}
+const Vec{dim, T} = Tensor{1, dim, T, dim}
 
 const AllTensors{dim, T} = Union{SymmetricTensor{2, dim, T}, Tensor{2, dim, T},
                                  SymmetricTensor{4, dim, T}, Tensor{4, dim, T},

--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -19,6 +19,10 @@
 @inline Base.:*(n::Number, S::AbstractTensor) = _map(x -> n*x, S)
 @inline Base.:/(S::AbstractTensor, n::Number) = _map(x -> x/n, S)
 
+@inline Base.:*(S::AbstractTensor, n::Tensor{1,1,T,1}) where {T} = _map(x -> x*n[1], S)
+@inline Base.:*(n::Tensor{1,1,T,1}, S::AbstractTensor) where {T} = _map(x -> n[1]*x, S)
+@inline Base.:/(S::AbstractTensor, n::Tensor{1,1,T,1}) where {T} = _map(x -> x/n[1], S)
+
 Base.:+(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimension and order must match"))
 Base.:-(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimension and order must match"))
 

--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -19,11 +19,6 @@
 @inline Base.:*(n::Number, S::AbstractTensor) = _map(x -> n*x, S)
 @inline Base.:/(S::AbstractTensor, n::Number) = _map(x -> x/n, S)
 
-@inline Base.:*(S::Tensor{1,1,T,1}, n::Tensor{1,1,T,1}) where {T} = _map(x -> x[1]*n[1], S)
-@inline Base.:*(S::AbstractTensor, n::Tensor{1,1,T,1}) where {T} = _map(x -> x*n[1], S)
-@inline Base.:*(n::Tensor{1,1,T,1}, S::AbstractTensor) where {T} = _map(x -> n[1]*x, S)
-@inline Base.:/(S::AbstractTensor, n::Tensor{1,1,T,1}) where {T} = _map(x -> x/n[1], S)
-
 Base.:+(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimension and order must match"))
 Base.:-(S1::AbstractTensor, S2::AbstractTensor) = throw(DimensionMismatch("dimension and order must match"))
 

--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -19,6 +19,7 @@
 @inline Base.:*(n::Number, S::AbstractTensor) = _map(x -> n*x, S)
 @inline Base.:/(S::AbstractTensor, n::Number) = _map(x -> x/n, S)
 
+@inline Base.:*(S::Tensor{1,1,T,1}, n::Tensor{1,1,T,1}) where {T} = _map(x -> x[1]*n[1], S)
 @inline Base.:*(S::AbstractTensor, n::Tensor{1,1,T,1}) where {T} = _map(x -> x*n[1], S)
 @inline Base.:*(n::Tensor{1,1,T,1}, S::AbstractTensor) where {T} = _map(x -> n[1]*x, S)
 @inline Base.:/(S::AbstractTensor, n::Tensor{1,1,T,1}) where {T} = _map(x -> x/n[1], S)

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -155,6 +155,31 @@ function Base.inv(t::SymmetricTensor{4, dim, T}) where {dim, T}
     frommandel(SymmetricTensor{4, dim}, inv(tomandel(t)))
 end
 
+"""
+    inv(::Tensor{order, dim})
+
+Compute the pseudo-inverse of a tensor.
+"""
+function LinearAlgebra.pinv(t::Vec{dim}) where {dim}
+    t / LinearAlgebra.norm(t)
+end
+
+function LinearAlgebra.pinv(t::Tensor{2, dim}) where {dim}
+    Base.inv(t)
+end
+
+function LinearAlgebra.pinv(t::SymmetricTensor{2, dim}) where {dim}
+    Base.inv(t)
+end
+
+function LinearAlgebra.pinv(t::Tensor{4, dim}) where {dim}
+    Base.inv(t)
+end
+
+function LinearAlgebra.pinv(t::SymmetricTensor{4, dim, T}) where {dim, T}
+    Base.inv(t)
+end
+
 Base.:\(S1::SecondOrderTensor, S2::AbstractTensor) = inv(S1) ⋅ S2
 
 """

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -160,8 +160,8 @@ end
 
 Compute the pseudo-inverse of a tensor.
 """
-function LinearAlgebra.pinv(t::Vec{dim}) where {dim}
-    t / LinearAlgebra.norm(t)
+function LinearAlgebra.pinv(t::Vec{dim, T}) where {dim, T}
+    LinearAlgebra.Transpose{T, Vec{dim, T}}(t / LinearAlgebra.norm(t))
 end
 
 function LinearAlgebra.pinv(t::Tensor{2, dim}) where {dim}

--- a/src/tensor_ops_errors.jl
+++ b/src/tensor_ops_errors.jl
@@ -3,8 +3,8 @@ function Base.:*(S1::AbstractTensor, S2::AbstractTensor)
     error("use `⋅` (`\\cdot`) for single contraction and `⊡` (`\\boxdot`) for double contraction instead of `*`")
 end
 
-for f in (:transpose, :adjoint)
-    @eval function LinearAlgebra.$f(::Vec)
-        throw(ArgumentError("the (no-op) $($f) is discontinued for `Tensors.Vec`"))
-    end
-end
+# for f in (:transpose, :adjoint)
+#     @eval function LinearAlgebra.$f(::Vec)
+#         throw(ArgumentError("the (no-op) $($f) is discontinued for `Tensors.Vec`"))
+#     end
+# end

--- a/src/tensor_ops_errors.jl
+++ b/src/tensor_ops_errors.jl
@@ -2,9 +2,3 @@
 function Base.:*(S1::AbstractTensor, S2::AbstractTensor)
     error("use `⋅` (`\\cdot`) for single contraction and `⊡` (`\\boxdot`) for double contraction instead of `*`")
 end
-
-# for f in (:transpose, :adjoint)
-#     @eval function LinearAlgebra.$f(::Vec)
-#         throw(ArgumentError("the (no-op) $($f) is discontinued for `Tensors.Vec`"))
-#     end
-# end

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -547,8 +547,8 @@ end
     @test_throws DimensionMismatch AA - A
 
     # transpose/adjoint of Vec
-    x = rand(Vec{3})
-    @test_throws ArgumentError x'
-    @test_throws ArgumentError transpose(x)
-    @test_throws ArgumentError adjoint(x)
+    # x = rand(Vec{3})
+    # @test_throws ArgumentError x'
+    # @test_throws ArgumentError transpose(x)
+    # @test_throws ArgumentError adjoint(x)
 end # of testset

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -545,10 +545,4 @@ end
     A2 = rand(Tensor{2, 2})
     @test_throws DimensionMismatch A + A2
     @test_throws DimensionMismatch AA - A
-
-    # transpose/adjoint of Vec
-    # x = rand(Vec{3})
-    # @test_throws ArgumentError x'
-    # @test_throws ArgumentError transpose(x)
-    # @test_throws ArgumentError adjoint(x)
 end # of testset


### PR DESCRIPTION
### Summary

1. Enable `tranpose` for first-order tensor
2. Add pseudo-inverse for `Vec{dim}`, `Tensor{2,dim}`, `SymmetricTensor{2, dim}`, `Tensor{4, dim}`, `SymmetricTensor{4, dim, T}`. 
- In the `Vec{dim}` case, `pinv` produces `Transpose{T, Vec{dim, T}}(t / norm(t))`
- In the last four cases, `pinv` is reduced to `inv`.

One example use case for `pinv` of tensors is the elastic simulation of 3D trusses. In a truss element, the reference domain `\xi` is 1D and the nodal coordinate `x` is in 3D. Here, `dx/d\xi` is not a square matrix so it's not invertible. Then, `pinv` needs to be used.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

- [x] I ran all tests on my computer and it's all green (i.e. `] test`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)