### PR TITLE
Redirect to stable docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; url=./stable/"/>


### PR DESCRIPTION
When going to [`https://ferrite-fem.github.io/Tensors.jl/`](https://ferrite-fem.github.io/Tensors.jl/), an old readme with outdated links is shown. I think this should fix that in the same way that @fredrikekre redirected the organization site to ferrite - but not exactly sure if it is possible/ok to have a pr to the gh-pages branch directly?

