### PR TITLE
Voigt symmetric bool

### DIFF
--- a/src/voigt.jl
+++ b/src/voigt.jl
@@ -176,7 +176,7 @@ Base.@propagate_inbounds function fromvoigt(TT::Type{<: SymmetricTensor{2, dim}}
     return TT(function (i, j)
             i > j && ((i, j) = (j, i))
             i == j ? (return v[offset + order[i, j]]) :
-                     (return v[offset + order[i, j]] / offdiagscale)
+                     (return v[offset + order[i, j]] * T(1 / offdiagscale) )
         end)
 end
 Base.@propagate_inbounds function fromvoigt(TT::Type{<: SymmetricTensor{4, dim}}, v::AbstractMatrix{T}; offdiagscale::T = T(1), offset_i::Int=0, offset_j::Int=0, order=DEFAULT_VOIGT_ORDER[dim]) where {dim, T}
@@ -184,8 +184,8 @@ Base.@propagate_inbounds function fromvoigt(TT::Type{<: SymmetricTensor{4, dim}}
             i > j && ((i, j) = (j, i))
             k > l && ((k, l) = (l, k))
             i == j && k == l ? (return v[offset_i + order[i, j], offset_j + order[k, l]]) :
-            i == j || k == l ? (return v[offset_i + order[i, j], offset_j + order[k, l]] / offdiagscale) :
-                               (return v[offset_i + order[i, j], offset_j + order[k, l]] / (offdiagscale * offdiagscale))
+            i == j || k == l ? (return v[offset_i + order[i, j], offset_j + order[k, l]] * T(one(T) / offdiagscale)) :
+                               (return v[offset_i + order[i, j], offset_j + order[k, l]] * T(one(T) / (offdiagscale * offdiagscale)))
         end)
 end
 

--- a/src/voigt.jl
+++ b/src/voigt.jl
@@ -184,8 +184,8 @@ Base.@propagate_inbounds function fromvoigt(TT::Type{<: SymmetricTensor{4, dim}}
             i > j && ((i, j) = (j, i))
             k > l && ((k, l) = (l, k))
             i == j && k == l ? (return v[offset_i + order[i, j], offset_j + order[k, l]]) :
-            i == j || k == l ? (return v[offset_i + order[i, j], offset_j + order[k, l]] * T(one(T) / offdiagscale)) :
-                               (return v[offset_i + order[i, j], offset_j + order[k, l]] * T(one(T) / (offdiagscale * offdiagscale)))
+            i == j || k == l ? (return v[offset_i + order[i, j], offset_j + order[k, l]] * T(1 / offdiagscale)) :
+                               (return v[offset_i + order[i, j], offset_j + order[k, l]] * T(1 / (offdiagscale * offdiagscale)))
         end)
 end
 

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -288,6 +288,12 @@ end
     @test (@inferred tomandel(AA)) * (@inferred tomandel(A)) ≈ tomandel(AA ⊡ A)
     @test (@inferred frommandel(Tensor{2,dim}, tomandel(A))) ≈ A
     @test (@inferred frommandel(Tensor{4,dim}, tomandel(AA))) ≈ AA
+
+    if T==Float64
+        num_components = Int((dim^2+dim)/2)
+        @test isa(fromvoigt(SymmetricTensor{2,dim}, rand(num_components) .> 0.5), SymmetricTensor{2,dim,Bool})
+        @test isa(fromvoigt(SymmetricTensor{4,dim}, rand(num_components,num_components) .> 0.5), SymmetricTensor{4,dim,Bool})
+    end
 end
 end # of testsection
 end # of testsection


### PR DESCRIPTION
When converting a boolean vector to a symmetric tensor, using the Voigt format, the result is a Float64 tensor:
```julia
typeof(fromvoigt(SymmetricTensor{2,2}, rand(Float32,3).>0))
SymmetricTensor{2, 2, Float64, 3}

typeof(fromvoigt(SymmetricTensor{2,2}, rand(Float32,3)))
SymmetricTensor{2, 2, Float32, 3}

# No problem with full tensor:
typeof(fromvoigt(Tensor{2,2}, rand(Float32,4).>0))
Tensor{2, 2, Bool, 4}

```

The reason is division by `true`, which gives a Float64, see [voigt.jl#L179](https://github.com/Ferrite-FEM/Tensors.jl/blob/3ff7c906048fcd0ddcd7d3530dc94b08925407bc/src/voigt.jl#L179)

My suggestion here is to use `T(1/offdiagonalscale)` on L179 (and similar for 4th order). 
I could not see any performance change for regular Float64 input.