### PR TITLE
Make otimesu and otimesl faster for symmetric tensors

### DIFF
--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -184,8 +184,8 @@ julia> otimesu(A, B)
 ```
 """
 @inline function otimesu(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim}) where {dim}
-    S1_ = Tensor{2,dim}(S1) # Convert to full tensor if symmetric to make 10x faster...
-    S2_ = Tensor{2,dim}(S2)
+    S1_ = convert(Tensor{2,dim}, S1) # Convert to full tensor if symmetric to make 10x faster... (see Tensors.jl#164)
+    S2_ = convert(Tensor{2,dim}, S2)
     return Tensor{4, dim}((i,j,k,l) -> S1_[i,k] * S2_[j,l])
 end
 

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -184,8 +184,8 @@ julia> otimesu(A, B)
 ```
 """
 @inline function otimesu(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim}) where {dim}
-    S1_ = convert(Tensor{2,dim}, S1) # Convert to full tensor if symmetric to make 10x faster... (see Tensors.jl#164)
-    S2_ = convert(Tensor{2,dim}, S2)
+    S1_ = convert(Tensor, S1) # Convert to full tensor if symmetric to make 10x faster... (see Tensors.jl#164)
+    S2_ = convert(Tensor, S2)
     return Tensor{4, dim}((i,j,k,l) -> S1_[i,k] * S2_[j,l])
 end
 
@@ -220,8 +220,8 @@ julia> otimesl(A, B)
 ```
 """
 @inline function otimesl(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim}) where {dim}
-    S1_ = convert(Tensor{2,dim}, S1) # Convert to full tensor if symmetric to make 10x faster... (see Tensors.jl#164)
-    S2_ = convert(Tensor{2,dim}, S2)
+    S1_ = convert(Tensor, S1) # Convert to full tensor if symmetric to make 10x faster... (see Tensors.jl#164)
+    S2_ = convert(Tensor, S2)
     return Tensor{4, dim}((i,j,k,l) -> S1_[i,l] * S2_[j,k])
 end
 

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -184,7 +184,9 @@ julia> otimesu(A, B)
 ```
 """
 @inline function otimesu(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim}) where {dim}
-    return Tensor{4, dim}((i,j,k,l) -> S1[i,k] * S2[j,l])
+    S1_ = Tensor{2,dim}(S1) # Convert to full tensor if symmetric to make 10x faster...
+    S2_ = Tensor{2,dim}(S2)
+    return Tensor{4, dim}((i,j,k,l) -> S1_[i,k] * S2_[j,l])
 end
 
 """
@@ -218,7 +220,9 @@ julia> otimesl(A, B)
 ```
 """
 @inline function otimesl(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim}) where {dim}
-    return Tensor{4, dim}((i,j,k,l) -> S1[i,l] * S2[j,k])
+    S1_ = Tensor{2,dim}(S1) # Convert to full tensor if symmetric to make 10x faster...
+    S2_ = Tensor{2,dim}(S2)
+    return Tensor{4, dim}((i,j,k,l) -> S1_[i,l] * S2_[j,k])
 end
 
 """

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -220,8 +220,8 @@ julia> otimesl(A, B)
 ```
 """
 @inline function otimesl(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim}) where {dim}
-    S1_ = Tensor{2,dim}(S1) # Convert to full tensor if symmetric to make 10x faster...
-    S2_ = Tensor{2,dim}(S2)
+    S1_ = convert(Tensor{2,dim}, S1) # Convert to full tensor if symmetric to make 10x faster... (see Tensors.jl#164)
+    S2_ = convert(Tensor{2,dim}, S2)
     return Tensor{4, dim}((i,j,k,l) -> S1_[i,l] * S2_[j,k])
 end
 


### PR DESCRIPTION
See #164 

## Timings 
Too large variance to determine if this has any negative effect when giving full tensors), but doesn't seem to have any significant effect... 

```julia
a, b = (rand(Tensor{2,3}) for _ in 1:2);
as, bs = (rand(SymmetricTensor{2,3}) for _ in 1:2);`
```

Command | Master | PR
--- | --- | ---
`@btime otimesu($a, $b);` | 13.627 ns | 10.611 ns | 
`@btime otimesu($as, $bs);` | 334.421 ns |  20.641 ns | 
`@btime otimesl($a, $b);` | 18.437 ns | 11.700 ns | 
`@btime otimesl($as, $bs);` | 343.071 ns | 25.451 ns | 