### PR TITLE
Remove precompilation for gensym:ed function name

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -25,10 +25,4 @@ using PrecompileTools
 
         # TODO: AD?
     end
-
-    # See discussion in https://github.com/Ferrite-FEM/Tensors.jl/pull/190
-    if @isdefined var"#102#103"
-        precompile(Tuple{typeof(apply_all), Type{Tensor{1, 2, T, M} where M where T}, var"#102#103"{Float64}})
-        precompile(Tuple{typeof(apply_all), Type{Tensor{1, 3, T, M} where M where T}, var"#102#103"{Float64}})
-    end
 end


### PR DESCRIPTION
See discussion in #190, this caused a failure later for unrelated changes in #233 and #188.