### PR TITLE
Rotate with precomputed rotation tensor

### DIFF
--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -407,24 +407,32 @@ function rotation_tensor(u::Vec{3, T}, θ::Number) where T
     return one(ω) + s * ω + (1 - c) * ω^2
 end
 
-# args is (u::Vec{3}, θ::Number) for 3D tensors, and (θ::number,) for 2D
-function rotate(x::SymmetricTensor{2}, args...)
-    R = rotation_tensor(args...)
+function rotate(x::Vec{2}, R::Tensor{2})
+    return R ⋅ x
+end
+
+function rotate(x::Vec{3}, R::Tensor{2})
+    return R ⋅ x
+end
+
+function rotate(x::SymmetricTensor{2}, R::Tensor{2})
     return unsafe_symmetric(R ⋅ x ⋅ R')
 end
-function rotate(x::Tensor{2}, args...)
-    R = rotation_tensor(args...)
+
+function rotate(x::Tensor{2}, R::Tensor{2})
     return R ⋅ x ⋅ R'
 end
-function rotate(x::Tensor{3}, args...)
-    R = rotation_tensor(args...)
+
+function rotate(x::Tensor{3}, R::Tensor{2})
     return otimesu(R, R) ⊡ x ⋅ R'
 end
-function rotate(x::Tensor{4}, args...)
-    R = rotation_tensor(args...)
-    return otimesu(R, R) ⊡ x ⊡ otimesu(R', R')
-end
-function rotate(x::SymmetricTensor{4}, args...)
-    R = rotation_tensor(args...)
+
+function rotate(x::SymmetricTensor{4}, R::Tensor{2})
     return unsafe_symmetric(otimesu(R, R) ⊡ x ⊡ otimesu(R', R'))
 end
+
+function rotate(x::Tensor{4}, R::Tensor{2})
+    return otimesu(R, R) ⊡ x ⊡ otimesu(R', R')
+end
+
+rotate(x::AbstractTensor, args...) = rotate(x, rotation_tensor(args...))

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -407,32 +407,31 @@ function rotation_tensor(u::Vec{3, T}, θ::Number) where T
     return one(ω) + s * ω + (1 - c) * ω^2
 end
 
-function rotate(x::Vec{2}, R::Tensor{2})
+function rotate(x::Vec{dim}, R::Tensor{2, dim}) where {dim}
     return R ⋅ x
 end
 
-function rotate(x::Vec{3}, R::Tensor{2})
-    return R ⋅ x
-end
-
-function rotate(x::SymmetricTensor{2}, R::Tensor{2})
+function rotate(x::SymmetricTensor{2, dim}, R::Tensor{2, dim}) where {dim}
     return unsafe_symmetric(R ⋅ x ⋅ R')
 end
 
-function rotate(x::Tensor{2}, R::Tensor{2})
+function rotate(x::Tensor{2, dim}, R::Tensor{2, dim}) where {dim}
     return R ⋅ x ⋅ R'
 end
 
-function rotate(x::Tensor{3}, R::Tensor{2})
+function rotate(x::Tensor{3, dim}, R::Tensor{2, dim}) where {dim}
     return otimesu(R, R) ⊡ x ⋅ R'
 end
 
-function rotate(x::SymmetricTensor{4}, R::Tensor{2})
+function rotate(x::SymmetricTensor{4, dim}, R::Tensor{2, dim}) where {dim}
     return unsafe_symmetric(otimesu(R, R) ⊡ x ⊡ otimesu(R', R'))
 end
 
-function rotate(x::Tensor{4}, R::Tensor{2})
+function rotate(x::Tensor{4, dim}, R::Tensor{2, dim}) where {dim}
     return otimesu(R, R) ⊡ x ⊡ otimesu(R', R')
 end
 
-rotate(x::AbstractTensor, args...) = rotate(x, rotation_tensor(args...))
+#rotate(x::AbstractTensor, args...) = rotate(x, rotation_tensor(args...))
+rotate(x::AbstractTensor{<:Any, 2}, θ::Number) = rotate(x, rotation_tensor(θ))
+rotate(x::AbstractTensor{<:Any, 3}, u::Vec{3}, θ::Number) = rotate(x, rotation_tensor(u, θ))
+rotate(x::AbstractTensor{<:Any, 3}, ψ::Number, θ::Number, ϕ::Number) = rotate(x, rotation_tensor(ψ, θ, ϕ))


### PR DESCRIPTION
This is not solving any open issue.
In many occasions I needed to rotate multiple tensors with the same rotation tensor R. 
Since R is currently recomputed every time, I thought it could be useful to pass a precomputed rotation tensor directly. 
This also should allow using rotation tensors built with conventions other than the ones provided by rotation_tensor.

<details>
<summary>Benchmark: compute R — original vs PR (median, μs)</summary>

| case | original | PR|
|------|----------|------------|
| SymmetricTensor{2,2,Float64} | 0.069 | 0.071 |
| SymmetricTensor{2,3,Float64} | 0.094 | 0.094 |
| SymmetricTensor{4,3,Float64} | 0.300 | 0.593 |
| Tensor{2,2,Float64}          | 0.068 | 0.072 |
| Tensor{2,3,Float64}          | 0.099 | 0.082 |
| Tensor{3,3,Float64}          | 0.247 | 0.244 |
| Tensor{4,3,Float64}          | 0.816 | 0.261 |
| Vec{2,Float64}               | 0.058 | 0.059 |
| Vec{3,Float64}               | 0.089 | 0.084 |

</details>

<details>
<summary>Benchmark: precomputed R vs computing R (median, μs)</summary>

| case | computing R | precomputed R |
|------|------------|---------------|
| SymmetricTensor{2,2,Float64} | 0.071 | 0.058 |
| SymmetricTensor{2,3,Float64} | 0.094 | 0.065 |
| SymmetricTensor{4,3,Float64} | 0.593 | 0.319 |
| Tensor{2,2,Float64}          | 0.072 | 0.048 |
| Tensor{2,3,Float64}          | 0.082 | 0.049 |
| Tensor{3,3,Float64}          | 0.244 | 0.096 |
| Tensor{4,3,Float64}          | 0.261 | 0.247 |
| Vec{2,Float64}               | 0.059 | 0.042 |
| Vec{3,Float64}               | 0.084 | 0.044 |

</details>

<details>
<summary>Benchmark script</summary>

```julia

using Tensors, BenchmarkTools, LinearAlgebra, Printf

const SUITE = BenchmarkGroup()
const θ_bench, ψ_bench, ϕ_bench = π / 4, π/6, π/3
const u3_bench = normalize(Vec{3}((0.0, 1.0, 1.0)))
const HAS_PRECOMP = hasmethod(rotate, (Vec{2, Float64}, Tensor{2, 2, Float64, 4}))
println("Precomputed R overloads: ", HAS_PRECOMP ? "YES" : "NO")

SUITE["rotate"] = BenchmarkGroup()
HAS_PRECOMP && (SUITE["rotate_precomp"] = BenchmarkGroup())

for T in (Float32, Float64)
    v2   = rand(Vec{2, T})
    v3   = rand(Vec{3, T})
    T2_2 = rand(Tensor{2,2,T})
    T2_3 = rand(Tensor{2,3,T})
    T3_3 = rand(Tensor{3,3,T})
    T4_3 = rand(Tensor{4,3,T})
    S2_2 = rand(SymmetricTensor{2,2,T})
    S2_3 = rand(SymmetricTensor{2,3,T})
    S4_3 = rand(SymmetricTensor{4,3,T})

    SUITE["rotate"]["Vec{2,$T}"]               = @benchmarkable rotate($v2, $θ_bench)
    SUITE["rotate"]["Vec{3,$T}"]               = @benchmarkable rotate($v3, $u3_bench, $θ_bench)
    SUITE["rotate"]["Tensor{2,2,$T}"]          = @benchmarkable rotate($T2_2, $θ_bench)
    SUITE["rotate"]["Tensor{2,3,$T}"]          = @benchmarkable rotate($T2_3, $u3_bench, $θ_bench)
    SUITE["rotate"]["Tensor{3,3,$T}"]          = @benchmarkable rotate($T3_3, $u3_bench, $θ_bench)
    SUITE["rotate"]["Tensor{4,3,$T}"]          = @benchmarkable rotate($T4_3, $u3_bench, $θ_bench)
    SUITE["rotate"]["SymmetricTensor{2,2,$T}"] = @benchmarkable rotate($S2_2, $θ_bench)
    SUITE["rotate"]["SymmetricTensor{2,3,$T}"] = @benchmarkable rotate($S2_3, $u3_bench, $θ_bench)
    SUITE["rotate"]["SymmetricTensor{4,3,$T}"] = @benchmarkable rotate($S4_3, $u3_bench, $θ_bench)

    if HAS_PRECOMP
        R2 = rotation_tensor(θ_bench)
        R3 = rotation_tensor(u3_bench, θ_bench)

        SUITE["rotate_precomp"]["Vec{2,$T}"]               = @benchmarkable rotate($v2, $R2)
        SUITE["rotate_precomp"]["Vec{3,$T}"]               = @benchmarkable rotate($v3, $R3)
        SUITE["rotate_precomp"]["Tensor{2,2,$T}"]          = @benchmarkable rotate($T2_2, $R2)
        SUITE["rotate_precomp"]["Tensor{2,3,$T}"]          = @benchmarkable rotate($T2_3, $R3)
        SUITE["rotate_precomp"]["Tensor{3,3,$T}"]          = @benchmarkable rotate($T3_3, $R3)
        SUITE["rotate_precomp"]["Tensor{4,3,$T}"]          = @benchmarkable rotate($T4_3, $R3)
        SUITE["rotate_precomp"]["SymmetricTensor{2,2,$T}"] = @benchmarkable rotate($S2_2, $R2)
        SUITE["rotate_precomp"]["SymmetricTensor{2,3,$T}"] = @benchmarkable rotate($S2_3, $R3)
        SUITE["rotate_precomp"]["SymmetricTensor{4,3,$T}"] = @benchmarkable rotate($S4_3, $R3)
    end
end

fmt_ns(t_ns) = @sprintf("%.3f μs", t_ns / 1e3)

function print_stats_table(group, label)
    println("\n── $label ──")
    @printf("%-35s %12s %12s %12s %12s\n", "case", "min", "median", "mean", "max")
    println("-"^87)
    for k in sort(collect(keys(group)))
        b = group[k]
        @printf("%-35s %12s %12s %12s %12s\n", k,
            fmt_ns(minimum(b).time),
            fmt_ns(median(b).time),
            fmt_ns(mean(b).time),
            fmt_ns(maximum(b).time))
    end
end

function print_comparison_table(precomp, original)
    println("\n── rotate_precomp vs rotate (median) ──")
    @printf("%-35s %12s %12s %8s %12s\n", "case", "precomp_R", "compute_R", "ratio", "judgment")
    println("-"^85)
    j = judge(median(precomp), median(original))
    for k in sort(collect(keys(precomp)))
        t_pre  = median(precomp[k]).time
        t_orig = median(original[k]).time
        @printf("%-35s %12s %12s %8.2f %12s\n", k,
            fmt_ns(t_pre), fmt_ns(t_orig), t_pre / t_orig, string(j[k].time))
    end
end

results = run(SUITE, verbose=true)

print_stats_table(results["rotate"], "rotate (R computed internally)")
if HAS_PRECOMP
    print_stats_table(results["rotate_precomp"], "rotate_precomp (R given)")
    print_comparison_table(results["rotate_precomp"], results["rotate"])
end
```

</details>