### PR TITLE
GPU compatible `fromvoigt`/`frommandel`

### DIFF
--- a/src/voigt.jl
+++ b/src/voigt.jl
@@ -3,7 +3,7 @@ const DEFAULT_VOIGT_ORDER = (
     @SMatrix([1 3; 4 2]),
     @SMatrix([1 6 5; 9 2 4; 8 7 3])
     )
-    
+
 """
     tovoigt([type::Type{<:AbstractArray}, ]A::Union{SecondOrderTensor, FourthOrderTensor}; kwargs...)
 

--- a/src/voigt.jl
+++ b/src/voigt.jl
@@ -1,4 +1,6 @@
-const DEFAULT_VOIGT_ORDER = ([1], [1 3; 4 2], [1 6 5; 9 2 4; 8 7 3])
+const DEFAULT_VOIGT_ORDER = (SMatrix{1,1,Int}(1),
+                             SMatrix{2,2,Int}(1, 4, 3, 2),
+                             SMatrix{3,3,Int}(1, 9, 8, 6, 2, 7, 5, 4, 3))
 """
     tovoigt([type::Type{<:AbstractArray}, ]A::Union{SecondOrderTensor, FourthOrderTensor}; kwargs...)
 

--- a/src/voigt.jl
+++ b/src/voigt.jl
@@ -1,6 +1,9 @@
-const DEFAULT_VOIGT_ORDER = (SMatrix{1,1,Int}(1),
-                             SMatrix{2,2,Int}(1, 4, 3, 2),
-                             SMatrix{3,3,Int}(1, 9, 8, 6, 2, 7, 5, 4, 3))
+const DEFAULT_VOIGT_ORDER = (
+    @SMatrix([1]),
+    @SMatrix([1 3; 4 2]),
+    @SMatrix([1 6 5; 9 2 4; 8 7 3])
+    )
+    
 """
     tovoigt([type::Type{<:AbstractArray}, ]A::Union{SecondOrderTensor, FourthOrderTensor}; kwargs...)
 

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -16,6 +16,7 @@ A = rand(Tensor{2, dim, T})
 B = rand(Tensor{2, dim, T})
 a = rand(Tensor{1, dim, T})
 b = rand(Tensor{1, dim, T})
+@show A # Temporary for debugging
 
 AA_sym = rand(SymmetricTensor{4, dim, T})
 BB_sym = rand(SymmetricTensor{4, dim, T})

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -16,11 +16,6 @@ A = rand(Tensor{2, dim, T})
 B = rand(Tensor{2, dim, T})
 a = rand(Tensor{1, dim, T})
 b = rand(Tensor{1, dim, T})
-if !(dott(A) ≈ dot(A, transpose(A)))
-    @show A
-    @show dott(A)
-    @show dot(A, transpose(A))
-end
 
 AA_sym = rand(SymmetricTensor{4, dim, T})
 BB_sym = rand(SymmetricTensor{4, dim, T})

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -19,7 +19,7 @@ b = rand(Tensor{1, dim, T})
 if !(dott(A) ≈ dot(A, transpose(A)))
     @show A
     @show dott(A)
-    @show dot(A, transpose(A)))
+    @show dot(A, transpose(A))
 end
 
 AA_sym = rand(SymmetricTensor{4, dim, T})

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -16,7 +16,11 @@ A = rand(Tensor{2, dim, T})
 B = rand(Tensor{2, dim, T})
 a = rand(Tensor{1, dim, T})
 b = rand(Tensor{1, dim, T})
-@show A # Temporary for debugging
+if !(dott(A) ≈ dot(A, transpose(A)))
+    @show A
+    @show dott(A)
+    @show dot(A, transpose(A)))
+end
 
 AA_sym = rand(SymmetricTensor{4, dim, T})
 BB_sym = rand(SymmetricTensor{4, dim, T})


### PR DESCRIPTION
Currently `fromvoigt`/`frommandel` fails on GPU due to closure kept on CPU matrix `DEFAULT_VOIGT_ORDER`. 

Source code bug from :

https://github.com/termi-official/FerriteOperators.jl/blob/e213d7a010d5e7e85d5844334fcf2f43347a0fe4/src/elements/simple_linear_viscoelasticity.jl#L215-L219
 

And MWE to reproduce the issue is as follows: 

```
using Tensors
using StaticArrays
using KernelAbstractions
using CUDA
import KernelAbstractions as KA

@kernel function frommandel_kernel!(out, @Const(inp))
    i = @index(Global, Linear)
    @inbounds begin
        v = SVector{6,Float64}(ntuple(k -> inp[k, i], Val(6)))
        T = frommandel(SymmetricTensor{2,3}, v)
        for k in 1:6
            out[k, i] = T.data[k]
        end
    end
end

function run_frommandel(backend; n = 8)
    inp = KA.allocate(backend, Float64, 6, n)
    copyto!(inp, repeat(Float64.(1:6), 1, n))
    out = KA.zeros(backend, Float64, 6, n)
    frommandel_kernel!(backend)(out, inp; ndrange = n)
    KA.synchronize(backend)
    return Array(out)
end

println("=== CPU (reference) ===")
cpu = run_frommandel(CPU())
display(cpu[:, 1]); println()

println("\n=== GPU (CUDA) ===")
if CUDA.functional()
    gpu = run_frommandel(CUDABackend())
    display(gpu[:, 1]); println()
    println("\nGPU matches CPU: ", isapprox(cpu, gpu))
else
    println("CUDA not functional — skipping GPU section.")
end
```


