### PR TITLE
compat: Support upcoming TypeEgal in get_type

### DIFF
--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -152,7 +152,11 @@ end
 # Steal base implementation of "prod" to safely mark with @pure 
 @pure n_components(::Type{MixedTensor{order, dims}}) where {order, dims} = *(size(MixedTensor{order, dims})...)
 
-@pure get_type(::Type{Type{X}}) where {X} = X
+if isdefined(Core, :TypeEgal)
+    get_type(T::Union{Core.TypeEq, Core.TypeEgal}) = Base.type_parameter(T)
+else
+    @pure get_type(::Type{Type{X}}) where {X} = X
+end
 
 @pure get_base(::Type{<:Tensor{order, dim}})          where {order, dim} = Tensor{order, dim}
 @pure get_base(::Type{<:SymmetricTensor{order, dim}}) where {order, dim} = SymmetricTensor{order, dim}


### PR DESCRIPTION
This adjusts to upcoming https://github.com/JuliaLang/julia/pull/62001, where `Type{Type{X}}` is too narrow to capture a `TypeEgal` passed into a generated function. This function could be adjusted to `Type{<:Type{X}}`, but we can also just bypass the subtyping machinery entirely, remove the type parameter and get it directly from the type. That might have marginally better performance, although it probably doesn't matter inside a generated function.

Keep the existing @pure Type{Type{X}} fallback for older Julia versions where TypeEgal is not defined.