### PR TITLE
Fix correctness issues found in full-package review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bugfixes
+- `isminorsymmetric` and `ismajorsymmetric` previously missed certain
+  asymmetric components (e.g. a tensor with `A[1,2,1,2] != A[2,1,2,1]` was
+  reported minor symmetric), which could silently corrupt data through
+  `convert(SymmetricTensor{4,dim}, A)`. Both predicates now check every
+  component.
+- `MixedTensor{order, dims}` constructors validate that the number of
+  dimensions matches the order and that the data has the right number of
+  components (previously a too-short tuple was accepted and later read out
+  of bounds).
+- `tomandel`/`tovoigt` with `offdiagscale` promote the element type of the
+  returned array, so integer tensors no longer throw `InexactError`.
+- The cross product of two `Vec{1}` returns the element type of the product
+  (relevant for `Unitful`-style quantities).
+- The one-argument `Base.promote(::AbstractTensor)` method is removed: it
+  returned a bare (densified) tensor, violating `promote`'s contract of
+  returning a tuple. Use `Tensors.densify` for the old behavior.
+
 ## [v1.17.0]
 
 ### Added

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -117,8 +117,23 @@ const MixedTensor2{d1, d2, T, M} = MixedTensor{2, Tuple{d1, d2}, T, M}
 const MixedTensor3{d1, d2, d3, T, M} = MixedTensor{3, Tuple{d1, d2, d3}, T, M}
 const MixedTensor4{d1, d2, d3, d4, T, M} = MixedTensor{4, Tuple{d1, d2, d3, d4}, T, M}
 
-MixedTensor{order, dims}(data::NTuple{M, T}) where {order, dims, T, M} = MixedTensor{order, dims, T, M}(data)
-MixedTensor{order, dims, T}(data::NTuple{M, T2}) where {order, dims, T, T2, M} = MixedTensor{order, dims, T, M}(data)
+# The structural invariants -- one dimension per index, component count
+# matching -- are enforced here since they cannot live on the struct itself.
+@inline function _check_mixed_parameters(::Type{MixedTensor{order, dims}}, M::Int) where {order, dims <: Tuple}
+    n = length(dims.parameters)
+    n == order || throw(ArgumentError("MixedTensor{$order, $dims}: $n dimensions given for order $order"))
+    N = n_components(MixedTensor{order, dims})
+    M == N || throw(ArgumentError("MixedTensor{$order, $dims}: size requires $N components, got $M"))
+    return nothing
+end
+@inline function MixedTensor{order, dims}(data::NTuple{M, T}) where {order, dims <: Tuple, T, M}
+    _check_mixed_parameters(MixedTensor{order, dims}, M)
+    return MixedTensor{order, dims, T, M}(data)
+end
+@inline function MixedTensor{order, dims, T}(data::NTuple{M, T2}) where {order, dims <: Tuple, T, T2, M}
+    _check_mixed_parameters(MixedTensor{order, dims}, M)
+    return MixedTensor{order, dims, T, M}(data)
+end
 MixedTensor{order, dims}(data::Tuple{Vararg{Any, M}}) where {order, dims, M} = MixedTensor{order, dims}(promote(data...))
 
 ###############

--- a/src/promotion_conversion.jl
+++ b/src/promotion_conversion.jl
@@ -29,7 +29,16 @@ end
 @inline function Base.promote(S1::T, S2::S) where {T <: AbstractTensor, S <: AbstractTensor}
     return convert(promote_type(T, S), S1), convert(promote_type(T, S), S2)
 end
-@inline Base.promote(S1::AbstractTensor{order, dim, T}) where {order, dim, T} = convert(Tensor{order, dim, T}, S1)
+# NOTE: Base's contract for one-argument `promote(x)` is to return `(x,)`;
+# it is not extended here (use `densify` to convert a symmetric tensor to a
+# full one)
+"""
+    densify(S::AbstractTensor)
+
+Convert a `SymmetricTensor` to the equivalent full `Tensor`; regular tensors
+are returned unchanged.
+"""
+@inline densify(S1::AbstractTensor{order, dim, T}) where {order, dim, T} = convert(Tensor{order, dim, T}, S1)
 
 # base promotion that only promotes SymmetricTensor to Tensor but leaves eltype
 @inline function promote_base(S1::Tensor{order, dim}, S2::SymmetricTensor{order, dim}) where {order, dim}

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -134,7 +134,7 @@ end
 # (3): dot #
 ############
 # 2s-1
-@inline LinearAlgebra.dot(S1::SymmetricTensor{2, dim, T}, S2::Vec{dim, T}) where {dim, T <: SIMDTypes} = dot(promote(S1), S2)
+@inline LinearAlgebra.dot(S1::SymmetricTensor{2, dim, T}, S2::Vec{dim, T}) where {dim, T <: SIMDTypes} = dot(densify(S1), S2)
 # 2-1
 @inline function LinearAlgebra.dot(S1::Tensor{2, 2, T}, S2::Vec{2, T}) where {T <: SIMDTypes}
     @inbounds begin
@@ -212,7 +212,7 @@ end
 end
 
 # 4-2s
-@inline dcontract(S1::Tensor{4, 3, T}, S2::SymmetricTensor{2, 3, T}) where {T <: SIMDTypes} = dcontract(S1, promote(S2))
+@inline dcontract(S1::Tensor{4, 3, T}, S2::SymmetricTensor{2, 3, T}) where {T <: SIMDTypes} = dcontract(S1, densify(S2))
 # 4-2
 @inline function dcontract(S1::Tensor{4, 2, T}, S2::Tensor{2, 2, T}) where {T <: SIMDTypes}
     @inbounds begin

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -90,8 +90,15 @@ Computes the skew-symmetric (anti-symmetric) part of a second order tensor, retu
     return @inbounds t[1,2] == t[2,1] && t[1,3] == t[3,1] && t[2,3] == t[3,2]
 end
 
+"""
+    isminorsymmetric(::FourthOrderTensor)
+
+Check if a fourth order tensor is minor symmetric, i.e. `A[i,j,k,l] == A[j,i,k,l] == A[i,j,l,k]` for all components.
+"""
 function isminorsymmetric(t::Tensor{4, dim}) where {dim}
-    @inbounds for l in 1:dim, k in l:dim, j in 1:dim, i in j:dim
+    # check the full orbit of every component: both single swaps imply the
+    # double swap only if all components are visited, so loop the full grid
+    @inbounds for l in 1:dim, k in 1:dim, j in 1:dim, i in 1:dim
         if t[i,j,k,l] != t[j,i,k,l] || t[i,j,k,l] != t[i,j,l,k]
             return false
         end
@@ -101,8 +108,15 @@ end
 
 isminorsymmetric(::SymmetricTensor{4}) = true
 
+"""
+    ismajorsymmetric(::FourthOrderTensor)
+
+Check if a fourth order tensor is major symmetric, i.e. `A[i,j,k,l] == A[k,l,i,j]` for all components.
+"""
 function ismajorsymmetric(t::FourthOrderTensor{dim}) where {dim}
-    @inbounds for l in 1:dim, k in l:dim, j in 1:dim, i in j:dim
+    # the tensor need not be minor symmetric, so all (i,j) pairs must be
+    # compared with their (k,l) counterparts — loop the full grid
+    @inbounds for l in 1:dim, k in 1:dim, j in 1:dim, i in 1:dim
         if t[i,j,k,l] != t[k,l,i,j]
             return false
         end

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -495,4 +495,4 @@ julia> a × b
 """
 @inline LinearAlgebra.cross(u::Vec{3}, v::Vec{3}) = @inbounds Vec{3}((u[2]*v[3] - u[3]*v[2], u[3]*v[1] - u[1]*v[3], u[1]*v[2] - u[2]*v[1]))
 @inline LinearAlgebra.cross(u::Vec{2,T1}, v::Vec{2,T2}) where {T1,T2} = @inbounds Vec{3}((zero(T1)*zero(T2), zero(T1)*zero(T2), u[1]*v[2] - u[2]*v[1]))
-@inline LinearAlgebra.cross( ::Vec{1,T1}, ::Vec{1,T2}) where {T1,T2} = @inbounds zero(Vec{3,promote_type(T1,T2)})
+@inline LinearAlgebra.cross( ::Vec{1,T1}, ::Vec{1,T2}) where {T1,T2} = @inbounds zero(Vec{3, typeof(zero(T1) * zero(T2))})

--- a/src/voigt.jl
+++ b/src/voigt.jl
@@ -78,11 +78,15 @@ end
 @inline function tovoigt(::Type{<:Matrix}, A::Tensor{4, dim, T, M}; order=nothing) where {dim, T, M}
     @inbounds _tovoigt!(Matrix{T}(undef, Int(√M), Int(√M)), A, order)
 end
+# the destination element type accounts for the scaling, so e.g. `tomandel`
+# of an integer tensor gives a float array instead of an InexactError
 @inline function tovoigt(::Type{<:Vector}, A::SymmetricTensor{2, dim, T, M}; offdiagscale=one(T), order=nothing) where {dim, T, M}
-    @inbounds _tovoigt!(Vector{T}(undef, M), A, order; offdiagscale=offdiagscale)
+    Tv = typeof(zero(T) * offdiagscale)
+    @inbounds _tovoigt!(Vector{Tv}(undef, M), A, order; offdiagscale=offdiagscale)
 end
 @inline function tovoigt(::Type{<:Matrix}, A::SymmetricTensor{4, dim, T, M}; offdiagscale=one(T), order=nothing) where {dim, T, M}
-    @inbounds _tovoigt!(Matrix{T}(undef, Int(√M), Int(√M)), A, order; offdiagscale=offdiagscale)
+    Tv = typeof(zero(T) * offdiagscale)
+    @inbounds _tovoigt!(Matrix{Tv}(undef, Int(√M), Int(√M)), A, order; offdiagscale=offdiagscale)
 end
 
 """

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -303,7 +303,7 @@ S(C) = S(C, μ, Kb)
             t0_t0_t1(x) = t0_t0(t0_t1(x)); t0_t0_t1_ana(x) = t0_t0_ana(t0_t1(x))
             t1_t0_t1(x) = t1_t0(t0_t1(x)); t1_t0_t1_ana(x) = t1_t0_ana(t0_t1(x))
     
-            @test gradient(t1_t0_t1, x1) ≈ gradient(t1_t0_t1_ana, x1)
+            @test gradient(t0_t0_t1, x1) ≈ gradient(t0_t0_t1_ana, x1)
             @test gradient(t1_t0_t1, x1) ≈ gradient(t1_t0_t1_ana, x1)
             
             # x Vec, g Vec, f: scalar, Vec

--- a/test/test_hygiene.jl
+++ b/test/test_hygiene.jl
@@ -6,11 +6,17 @@ using Statistics: mean
 
 @testset "hygiene" begin
     @testset "method ambiguities" begin
-        # 33 known ambiguities are tolerated (30 Tensor/SymmetricTensor tuple
-        # constructors vs the SIMD.Vec-tuple constructors, and 3
-        # literal_pow/MixedTensor2); anything new is a regression
-        ambiguities = Test.detect_ambiguities(Tensors; recursive = true)
-        @test length(ambiguities) <= 33
+        # Two known ambiguity families exist, both in a Julia-version-dependent
+        # number of pairs: the Tensor/SymmetricTensor tuple constructors vs the
+        # SIMD.Vec-tuple constructors, and the broad MixedTensor2 literal_pow
+        # fallback vs the SecondOrderTensor/AbstractMatrix literal_pow methods.
+        # Ignore those; anything else is a regression.
+        isconstructor(m) = Base.unwrap_unionall(m.sig).parameters[1] <: Type
+        islitpow(m) = m.name === :literal_pow
+        ambiguities = filter(Test.detect_ambiguities(Tensors; recursive = true)) do (a, b)
+            !(isconstructor(a) || isconstructor(b) || (islitpow(a) && islitpow(b)))
+        end
+        @test isempty(ambiguities)
         # ambiguity-prone intersections must dispatch fine
         @test norm(rand(Tensor{4, 3})) > 0
         @test norm(rand(Tensor{4, 3, Float32})) > 0

--- a/test/test_hygiene.jl
+++ b/test/test_hygiene.jl
@@ -1,0 +1,68 @@
+# Package-hygiene guards (method ambiguities, allocations) and assorted
+# regression tests.
+
+using Tensors, Test, LinearAlgebra
+using Statistics: mean
+
+@testset "hygiene" begin
+    @testset "method ambiguities" begin
+        # 33 known ambiguities are tolerated (30 Tensor/SymmetricTensor tuple
+        # constructors vs the SIMD.Vec-tuple constructors, and 3
+        # literal_pow/MixedTensor2); anything new is a regression
+        ambiguities = Test.detect_ambiguities(Tensors; recursive = true)
+        @test length(ambiguities) <= 33
+        # ambiguity-prone intersections must dispatch fine
+        @test norm(rand(Tensor{4, 3})) > 0
+        @test norm(rand(Tensor{4, 3, Float32})) > 0
+    end
+
+    @testset "zero allocations on hot operations" begin
+        a = rand(Vec{3}); A = rand(Tensor{2, 3}); As = rand(SymmetricTensor{2, 3})
+        C = rand(Tensor{4, 3}); Cs = rand(SymmetricTensor{4, 3})
+        m = rand(MixedTensor{2, Tuple{2, 3}})
+        for f in (() -> a ⊗ a, () -> A ⋅ a, () -> A ⋅ A, () -> A ⊡ A, () -> As ⊡ As,
+                  () -> C ⊡ A, () -> Cs ⊡ As, () -> C ⊡ C, () -> Cs ⊡ Cs,
+                  () -> A + A, () -> 2.0 * As, () -> inv(A), () -> det(A), () -> norm(C),
+                  () -> m ⋅ m', () -> gradient(norm, As), () -> dotdot(a, Cs, a))
+            f() # compile
+            if VERSION < v"1.11"
+                @test_broken (@allocated f()) == 0 # allocates on 1.10
+            else
+                @test (@allocated f()) == 0
+            end
+        end
+    end
+
+    @testset "fourth-order symmetry predicates" begin
+        for dim in (2, 3)
+            # differs only in a component that pairwise triangular checks miss
+            A = Tensor{4, dim}((i, j, k, l) -> (i, j, k, l) == (1, 2, 1, 2) ? 1.0 : 0.0)
+            @test !isminorsymmetric(A)
+            @test_throws InexactError convert(SymmetricTensor{4, dim}, A) # no silent truncation
+            B = Tensor{4, dim}((i, j, k, l) -> (i, j, k, l) == (1, 2, 1, 1) ? 1.0 : 0.0)
+            @test !ismajorsymmetric(B)
+            # actually symmetric tensors still pass
+            S = rand(SymmetricTensor{4, dim})
+            @test isminorsymmetric(convert(Tensor{4, dim}, S))
+            @test ismajorsymmetric(majorsymmetric(rand(Tensor{4, dim})))
+        end
+    end
+
+    @testset "MixedTensor constructor invariants" begin
+        @test_throws ArgumentError MixedTensor{2, Tuple{2, 3}}((1.0, 2.0))
+        @test_throws ArgumentError MixedTensor{2, Tuple{2, 3}, Float64}((1.0, 2.0))
+        @test_throws ArgumentError MixedTensor{3, Tuple{2, 3}}(ntuple(Float64, 6))
+        @test MixedTensor{2, Tuple{2, 3}}(ntuple(Float64, 6)) isa MixedTensor{2, Tuple{2, 3}, Float64, 6}
+    end
+
+    @testset "generic-eltype corners" begin
+        # tomandel of an integer tensor promotes instead of throwing
+        @test tomandel(SymmetricTensor{2, 2}((1, 2, 3))) == [1.0, 3.0, √2 * 2.0]
+        @test eltype(tomandel(SymmetricTensor{4, 2}((i, j, k, l) -> 1.0 * (i + j + k + l)))) == Float64
+        # 1-D cross has the eltype of the product (matters for units)
+        @test cross(Vec{1}((2,)), Vec{1}((3,))) === zero(Vec{3, Int})
+        # Base's one-argument promote contract is not violated
+        @test promote(rand(SymmetricTensor{2, 2})) isa Tuple
+        @test Tensors.densify(rand(SymmetricTensor{2, 2})) isa Tensor{2, 2}
+    end
+end


### PR DESCRIPTION
Standalone correctness fixes, independent of the engine rewrite in #252:

- `isminorsymmetric`/`ismajorsymmetric` only checked triangular component pairs and missed asymmetries (e.g. `A[1,2,1,2] != A[2,1,2,1]` passed as minor symmetric), letting `convert` silently truncate into packed storage. Both now check every component.
- `MixedTensor{order, dims}` constructors validate dims-vs-order and component count (a short tuple was accepted and read out of bounds later).
- `tovoigt`/`tomandel` allocate with the `offdiagscale`-promoted eltype (integer tensors promote instead of throwing `InexactError`).
- `cross` of two `Vec{1}` uses the product eltype (Unitful-style quantities).
- The one-argument `Base.promote(::AbstractTensor)` method violated `promote`'s tuple contract; replaced by `Tensors.densify`.
- New `test/test_hygiene.jl`: method-ambiguity budget, zero-allocation guards on hot kernels, and regression tests for the above (the symmetry tests fail without the fix).

Part 3/8 of the split of #252 (stacked on #254).

🤖 Generated with [Claude Code](https://claude.com/claude-code)