### PR TITLE
Add S^(p::Integer) for second order tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Non-literal integer powers of second-order tensors, `S^(n::Integer)` ([#239]).
+
 ### Bugfixes
 - `isminorsymmetric` and `ismajorsymmetric` previously missed certain
   asymmetric components (e.g. a tensor with `A[1,2,1,2] != A[2,1,2,1]` was
@@ -76,4 +79,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#233]: https://github.com/Ferrite-FEM/Tensors.jl/issues/233
 [#236]: https://github.com/Ferrite-FEM/Tensors.jl/issues/236
 [#238]: https://github.com/Ferrite-FEM/Tensors.jl/issues/238
+[#239]: https://github.com/Ferrite-FEM/Tensors.jl/issues/239
 [#240]: https://github.com/Ferrite-FEM/Tensors.jl/issues/240

--- a/docs/src/man/other_operators.md
+++ b/docs/src/man/other_operators.md
@@ -83,6 +83,24 @@ where ``\mathbf{I}`` is the second order identity tensor.
 Tensors.inv
 ```
 
+## Powers
+
+Integer powers of a second order tensor are defined as repeated single
+contractions, `A^2 == A ⋅ A`, with `A^0 == one(A)` and negative powers acting
+on the inverse, `A^-2 == inv(A) ⋅ inv(A)`. Both literal exponents (`A^3`) and
+runtime integers (`A^n`) are supported, and powers of a `SymmetricTensor`
+remain symmetric:
+
+```jldoctest
+julia> A = rand(SymmetricTensor{2,2});
+
+julia> A^3 ≈ A ⋅ A ⋅ A
+true
+
+julia> A^3 ≈ A^Int(3)
+true
+```
+
 ## Transpose
 
 Transpose of tensors is defined by changing the order of the tensor's "legs". The transpose of a vector/symmetric tensor is the vector/tensor itself. The transpose of a second order tensor can be written as:

--- a/src/basic_operations.jl
+++ b/src/basic_operations.jl
@@ -36,21 +36,46 @@ end
 end
 
 # power
-@inline Base.literal_pow(::typeof(^), S::SecondOrderTensor, ::Val{-1}) = inv(S)
-@inline Base.literal_pow(::typeof(^), S::SecondOrderTensor, ::Val{0})  = one(S)
-@inline Base.literal_pow(::typeof(^), S::SecondOrderTensor, ::Val{1})  = S
-@inline function Base.literal_pow(::typeof(^), S1::SecondOrderTensor, ::Val{p}) where {p}
-    p > 0 ? (S2 = S1; q = p) : (S2 = inv(S1); q = -p)
-    S3 = S2
-    for i in 2:q
-        S2 = _powdot(S2, S3)
-    end
-    S2
+@inline Base.literal_pow(::typeof(^), S::SecondOrderTensor, ::Val{p}) where {p} = S^p
+@inline function Base.literal_pow(::typeof(^), S::SecondOrderTensor, ::Val{-1})
+    p = -1
+    return S^p
 end
 
-function Base.literal_pow(::typeof(^), S::MixedTensor2, ::Val{p}) where {p}
-    throw(ArgumentError("The exponentiation, S^$p, is not defined for S::MixedTensor2"))
+# non-literal integer powers (issue #239). For small exponents this is the
+# same repeated-contraction evaluation as `literal_pow`, so `S^3` and
+# `S^(p::Int)` with `p = 3` give identical results; larger exponents use
+# exponentiation by squaring.
+@inline function Base.:^(S1::SecondOrderTensor, p::Integer)
+    p == 0 && return one(S1)
+    # checked: -typemin overflows silently and would recurse forever
+    p < 0 && return inv(S1)^(Base.checked_neg(p))
+    if p <= 4
+        S2 = S1
+        for i in 2:p
+            S2 = _powdot(S2, S1)
+        end
+        return S2
+    end
+    # exponentiation by squaring
+    t = trailing_zeros(p) + 1
+    p >>= t
+    S2 = S1
+    while (t -= 1) > 0
+        S2 = _powdot(S2, S2)
+    end
+    y = S2
+    while p > 0
+        t = trailing_zeros(p) + 1
+        p >>= t
+        while (t -= 1) >= 0
+            S2 = _powdot(S2, S2)
+        end
+        y = _powdot(y, S2)
+    end
+    return y
 end
+Base.:^(S::MixedTensor2, p::Integer) = throw(ArgumentError("The exponentiation, S^$p, is not defined for S::MixedTensor2"))
 
 @inline _powdot(S1::Tensor, S2::Tensor) = dot(S1, S2)
 @generated function _powdot(S1::SymmetricTensor{2, dim}, S2::SymmetricTensor{2, dim}) where {dim}

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -175,3 +175,19 @@ for T in (Float32, Float64), dim in (1,2,3), order in (1,2,4), TensorType in (Te
 end
 end # of testset
 
+@testset "non-literal integer powers (issue #239)" begin
+for S in (rand(Tensor{2, 3}), rand(SymmetricTensor{2, 3}))
+    @test S^3 == S^Int(3)
+    @test typeof(S^Int(3)) == typeof(S)
+    @test S^-2 == S^Int(-2)
+    @test S^Int(0) == one(S)
+    @test (@inferred S^Int(2)) isa typeof(S)
+    # exponentiation-by-squaring path
+    Sn = S / norm(S)
+    @test Sn^Int(9) ≈ foldl((a, _) -> Tensors._powdot(a, Sn), 1:8; init = Sn)
+    @test typeof(Sn^Int(9)) == typeof(Sn)
+end
+@test_throws ArgumentError rand(MixedTensor2{2, 3})^Int(2)
+# negative powers of typemin error instead of overflowing
+@test_throws OverflowError rand(Tensor{2, 2})^typemin(Int)
+end # of testset


### PR DESCRIPTION
Non-literal integer powers of second-order tensors via repeated contraction; exponents above 4 use power-by-squaring, negative powers go through `inv` with a `checked_neg` guard so `S^typemin(Int)` throws `OverflowError`. `literal_pow` forwards to the same evaluation, so `S^3` and `S^Int(3)` are bit-identical. Closes #239.

Part 4/8 of the split of #252 (stacked on #255).

🤖 Generated with [Claude Code](https://claude.com/claude-code)