### PR TITLE
Internal simplifications: drop @pure, simplify inv/apply_all/constructors/promotion

### DIFF
--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -1,7 +1,5 @@
 module Tensors
 
-import Base.@pure
-
 import Statistics
 using Statistics: mean
 using LinearAlgebra
@@ -134,7 +132,7 @@ end
     _check_mixed_parameters(MixedTensor{order, dims}, M)
     return MixedTensor{order, dims, T, M}(data)
 end
-MixedTensor{order, dims}(data::Tuple{Vararg{Any, M}}) where {order, dims, M} = MixedTensor{order, dims}(promote(data...))
+MixedTensor{order, dims}(data::Tuple) where {order, dims} = MixedTensor{order, dims}(promote(data...))
 
 ###############
 # Typealiases #
@@ -157,32 +155,30 @@ const NonSymmetricTensors{dim, T} = Union{Tensor{2, dim, T}, Tensor{4, dim, T}, 
 ##############################
 get_data(t::AbstractTensor) = t.data
 
-@pure n_components(::Type{SymmetricTensor{2, dim}}) where {dim} = dim*dim - div((dim-1)*dim, 2)
-@pure function n_components(::Type{SymmetricTensor{4, dim}}) where {dim}
+n_components(::Type{SymmetricTensor{2, dim}}) where {dim} = dim*dim - div((dim-1)*dim, 2)
+function n_components(::Type{SymmetricTensor{4, dim}}) where {dim}
     n = n_components(SymmetricTensor{2, dim})
     return n*n
 end
-@pure n_components(::Type{Tensor{order, dim}}) where {order, dim} = dim^order
-
-# Steal base implementation of "prod" to safely mark with @pure 
-@pure n_components(::Type{MixedTensor{order, dims}}) where {order, dims} = *(size(MixedTensor{order, dims})...)
+n_components(::Type{Tensor{order, dim}}) where {order, dim} = dim^order
+n_components(::Type{MixedTensor{order, dims}}) where {order, dims} = *(size(MixedTensor{order, dims})...)
 
 if isdefined(Core, :TypeEgal)
     get_type(T::Union{Core.TypeEq, Core.TypeEgal}) = Base.type_parameter(T)
 else
-    @pure get_type(::Type{Type{X}}) where {X} = X
+    get_type(::Type{Type{X}}) where {X} = X
 end
 
-@pure get_base(::Type{<:Tensor{order, dim}})          where {order, dim} = Tensor{order, dim}
-@pure get_base(::Type{<:SymmetricTensor{order, dim}}) where {order, dim} = SymmetricTensor{order, dim}
-@pure get_base(::Type{<:MixedTensor{order, dims}})    where {order, dims} = MixedTensor{order, dims}
+get_base(::Type{<:Tensor{order, dim}})          where {order, dim} = Tensor{order, dim}
+get_base(::Type{<:SymmetricTensor{order, dim}}) where {order, dim} = SymmetricTensor{order, dim}
+get_base(::Type{<:MixedTensor{order, dims}})    where {order, dims} = MixedTensor{order, dims}
 
-@pure Base.eltype(::Type{Tensor{order, dim, T, M}})          where {order, dim, T, M} = T
-@pure Base.eltype(::Type{Tensor{order, dim, T}})             where {order, dim, T}    = T
-@pure Base.eltype(::Type{Tensor{order, dim}})                where {order, dim}       = Any
-@pure Base.eltype(::Type{SymmetricTensor{order, dim, T, M}}) where {order, dim, T, M} = T
-@pure Base.eltype(::Type{SymmetricTensor{order, dim, T}})    where {order, dim, T}    = T
-@pure Base.eltype(::Type{SymmetricTensor{order, dim}})       where {order, dim}       = Any
+Base.eltype(::Type{Tensor{order, dim, T, M}})          where {order, dim, T, M} = T
+Base.eltype(::Type{Tensor{order, dim, T}})             where {order, dim, T}    = T
+Base.eltype(::Type{Tensor{order, dim}})                where {order, dim}       = Any
+Base.eltype(::Type{SymmetricTensor{order, dim, T, M}}) where {order, dim, T, M} = T
+Base.eltype(::Type{SymmetricTensor{order, dim, T}})    where {order, dim, T}    = T
+Base.eltype(::Type{SymmetricTensor{order, dim}})       where {order, dim}       = Any
 
 ############################
 # Abstract Array interface #
@@ -210,7 +206,7 @@ Base.length(::Type{Tensor{order, dim, T, M}}) where {order, dim, T, M} = M
 #########################
 # Internal constructors #
 #########################
-for (TensorType, orders) in ((SymmetricTensor, (2,4)), (Tensor, (2,3,4)))
+for (TensorType, orders) in ((SymmetricTensor, (2,4)), (Tensor, (1,2,3,4)))
     for order in orders, dim in (1, 2, 3)
         N = n_components(TensorType{order, dim})
         @eval begin
@@ -220,15 +216,6 @@ for (TensorType, orders) in ((SymmetricTensor, (2,4)), (Tensor, (2,3,4)))
         if N > 1 # To avoid overwriting ::Tuple{Any}
             # Heterogeneous tuple
             @eval @inline $TensorType{$order, $dim}(t::Tuple{Vararg{Any,$N}}) = $TensorType{$order, $dim}(promote(t...))
-        end
-    end
-    if TensorType == Tensor
-        for dim in (1, 2, 3)
-            @eval @inline Tensor{1, $dim}(t::NTuple{$dim, T}) where {T} = Tensor{1, $dim, T, $dim}(t)
-            if dim > 1 # To avoid overwriting ::Tuple{Any}
-                # Heterogeneous tuple
-                @eval @inline Tensor{1, $dim}(t::Tuple{Vararg{Any,$dim}}) = Tensor{1, $dim}(promote(t...))
-            end
         end
     end
 end

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -18,19 +18,14 @@
     end
 end
 
-# Applies the function f to all indices f(1), f(2), ... f(n_independent_components)
-@generated function apply_all(S::Union{Type{Tensor{order, dim}}, Type{SymmetricTensor{order, dim}}, Type{MixedTensor{order, dim}}}, f::Function) where {order, dim}
-    TensorType = get_base(get_type(S))
-    exp = tensor_create_linear(TensorType, (i) -> :(f($i)))
-    quote
-        $(Expr(:meta, :inline))
-        @inbounds return $TensorType($exp)
-    end
+# Applies the function f to all linear indices: TT((f(1), f(2), ..., f(M))).
+# (Base's tuple `map` is not usable here: it leaves the unrolled path beyond
+# 32 components, e.g. Tensor{4, 3} with 81.)
+@inline function apply_all(::Type{TT}, f::F) where {TT <: Union{Tensor, SymmetricTensor, MixedTensor}, F <: Function}
+    B = get_base(TT)
+    return B(ntuple(f, Val(n_components(B))))
 end
-
-@inline function apply_all(S::Union{Tensor{order, dim}, SymmetricTensor{order, dim}, MixedTensor{order, dim}}, f::Function) where {order, dim}
-    apply_all(get_base(typeof(S)), f)
-end
+@inline apply_all(S::AbstractTensor, f::F) where {F <: Function} = apply_all(get_base(typeof(S)), f)
 
 # Tensor from AbstractArray
 function Tensor{order, dim}(data::AbstractArray) where {order, dim}
@@ -41,22 +36,16 @@ end
 
 
 # SymmetricTensor from AbstractArray
-@generated function SymmetricTensor{order, dim}(data::AbstractArray) where {order, dim}
-    N = n_components(Tensor{order,dim})
-    expN = Expr(:tuple, [:(data[$i]) for i in 1:N]...)
-    M = n_components(SymmetricTensor{order,dim})
-    expM = Expr(:tuple, [:(data[$i]) for i in 1:M]...)
-    return quote
-        L = length(data)
-        if L != $N && L != $M
-            throw(ArgumentError("wrong number of vector elements, expected $($N) or $($M), got $L"))
-        end
-        if L == $M
-            @inbounds return SymmetricTensor{order, dim}($expM)
-        end
-        @inbounds S = Tensor{order, dim}($expN)
-        return convert(SymmetricTensor{order, dim}, S)
+function SymmetricTensor{order, dim}(data::AbstractArray) where {order, dim}
+    N = n_components(Tensor{order, dim})
+    M = n_components(SymmetricTensor{order, dim})
+    L = length(data)
+    if L == M
+        return apply_all(SymmetricTensor{order, dim}, @inline function(i) @inbounds data[i]; end)
+    elseif L == N
+        return convert(SymmetricTensor{order, dim}, Tensor{order, dim}(data))
     end
+    throw(ArgumentError("wrong number of vector elements, expected $N or $M, got $L"))
 end
 
 # one (identity tensor)
@@ -105,8 +94,8 @@ end
 @inline Base.fill(f::Function, S::Type{T}) where {T <: Union{Tensor, SymmetricTensor, MixedTensor}} = apply_all(get_base(T), i -> f())
 
 # Array with zero/ones
-@inline Base.zeros(::Type{T}, dims::Int...) where {T <: Union{Tensor, SymmetricTensor, MixedTensor}} = fill(zero(T), (dims))
-@inline Base.ones(::Type{T}, dims::Int...) where {T <: Union{Tensor, SymmetricTensor, MixedTensor}} = fill(one(T), (dims))
+@inline Base.zeros(::Type{T}, dims::Int...) where {T <: Union{Tensor, SymmetricTensor, MixedTensor}} = fill(zero(T), dims)
+@inline Base.ones(::Type{T}, dims::Int...) where {T <: Union{Tensor, SymmetricTensor, MixedTensor}} = fill(one(T), dims)
 
 # diagm
 @generated function LinearAlgebra.diagm(S::Type{T}, v::Union{AbstractVector, Tuple}) where {T <: SecondOrderTensor}
@@ -144,27 +133,11 @@ julia> eᵢ(Vec{2, Float64}, 2)
  1.0
 ```
 """
-@inline function basevec(::Type{Vec{1, T}}) where {T}
-    o = one(T)
-    return (Vec{1, T}((o,)), )
-end
-@inline function basevec(::Type{Vec{2, T}}) where {T}
-    o = one(T)
-    z = zero(T)
-    return (Vec{2, T}((o, z)),
-            Vec{2, T}((z, o)))
-end
-@inline function basevec(::Type{Vec{3, T}}) where {T}
-    o = one(T)
-    z = zero(T)
-    return (Vec{3, T}((o, z, z)),
-            Vec{3, T}((z, o, z)),
-            Vec{3, T}((z, z, o)))
-end
+@inline basevec(::Type{Vec{dim, T}}) where {dim, T} = ntuple(i -> basevec(Vec{dim, T}, i), Val(dim))
 
 @inline basevec(::Type{Vec{dim}}) where {dim} = basevec(Vec{dim, Float64})
-@inline basevec(::Type{Vec{dim, T}}, i::Int) where {dim, T} = basevec(Vec{dim, T})[i]
-@inline basevec(::Type{Vec{dim}}, i::Int) where {dim} = basevec(Vec{dim, Float64})[i]
+@inline basevec(::Type{Vec{dim, T}}, i::Int) where {dim, T} = Vec{dim, T}(ntuple(j -> ifelse(j == i, one(T), zero(T)), Val(dim)))
+@inline basevec(::Type{Vec{dim}}, i::Int) where {dim} = basevec(Vec{dim, Float64}, i)
 @inline basevec(v::Vec{dim, T}) where {dim, T} = basevec(typeof(v))
 @inline basevec(v::Vec{dim, T}, i::Int) where {dim, T} = basevec(typeof(v), i)
 

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -98,86 +98,53 @@ julia> inv(A)
   588.35    282.819  -1587.79
 ```
 """
-@generated function Base.inv(t::Tensor{2, dim}) where {dim}
-    Tt = get_base(t)
-    idx(i,j) = compute_index(Tt, i, j)
-    if dim == 1
-        ex = :($Tt((dinv, )))
-    elseif dim == 2
-        ex = quote
-            v = get_data(t)
-            $Tt((v[$(idx(2,2))] * dinv, -v[$(idx(2,1))] * dinv,
-                -v[$(idx(1,2))] * dinv,  v[$(idx(1,1))] * dinv))
-        end
-    else # dim == 3
-        ex = quote
-            v = get_data(t)
-            $Tt(((v[$(idx(2,2))]*v[$(idx(3,3))] - v[$(idx(2,3))]*v[$(idx(3,2))]) * dinv,
-                -(v[$(idx(2,1))]*v[$(idx(3,3))] - v[$(idx(2,3))]*v[$(idx(3,1))]) * dinv,
-                 (v[$(idx(2,1))]*v[$(idx(3,2))] - v[$(idx(2,2))]*v[$(idx(3,1))]) * dinv,
+@inline Base.inv(t::Tensor{2, 1}) = Tensor{2, 1}((1 / det(t),))
+@inline function Base.inv(t::Tensor{2, 2})
+    dinv = 1 / det(t)
+    @inbounds Tensor{2, 2}((t[2,2] * dinv, -t[2,1] * dinv,
+                           -t[1,2] * dinv,  t[1,1] * dinv))
+end
+@inline function Base.inv(t::Tensor{2, 3})
+    dinv = 1 / det(t)
+    @inbounds Tensor{2, 3}((
+         (t[2,2]*t[3,3] - t[2,3]*t[3,2]) * dinv,
+        -(t[2,1]*t[3,3] - t[2,3]*t[3,1]) * dinv,
+         (t[2,1]*t[3,2] - t[2,2]*t[3,1]) * dinv,
 
-                -(v[$(idx(1,2))]*v[$(idx(3,3))] - v[$(idx(1,3))]*v[$(idx(3,2))]) * dinv,
-                 (v[$(idx(1,1))]*v[$(idx(3,3))] - v[$(idx(1,3))]*v[$(idx(3,1))]) * dinv,
-                -(v[$(idx(1,1))]*v[$(idx(3,2))] - v[$(idx(1,2))]*v[$(idx(3,1))]) * dinv,
+        -(t[1,2]*t[3,3] - t[1,3]*t[3,2]) * dinv,
+         (t[1,1]*t[3,3] - t[1,3]*t[3,1]) * dinv,
+        -(t[1,1]*t[3,2] - t[1,2]*t[3,1]) * dinv,
 
-                 (v[$(idx(1,2))]*v[$(idx(2,3))] - v[$(idx(1,3))]*v[$(idx(2,2))]) * dinv,
-                -(v[$(idx(1,1))]*v[$(idx(2,3))] - v[$(idx(1,3))]*v[$(idx(2,1))]) * dinv,
-                 (v[$(idx(1,1))]*v[$(idx(2,2))] - v[$(idx(1,2))]*v[$(idx(2,1))]) * dinv))
-        end
-    end
-    return quote
-        $(Expr(:meta, :inline))
-        dinv = 1 / det(t)
-        @inbounds return $ex
-    end
+         (t[1,2]*t[2,3] - t[1,3]*t[2,2]) * dinv,
+        -(t[1,1]*t[2,3] - t[1,3]*t[2,1]) * dinv,
+         (t[1,1]*t[2,2] - t[1,2]*t[2,1]) * dinv))
 end
 
-@generated function Base.inv(t::SymmetricTensor{2, dim}) where {dim}
-    Tt = get_base(t)
-    idx(i,j) = compute_index(Tt, i, j)
-    if dim == 1
-        ex = :($Tt((dinv, )))
-    elseif dim == 2
-        ex = quote
-            v = get_data(t)
-            $Tt((v[$(idx(2,2))] * dinv, -v[$(idx(2,1))] * dinv,
-                 v[$(idx(1,1))] * dinv))
-        end
-    else # dim == 3
-        ex = quote
-            v = get_data(t)
-            $Tt(((v[$(idx(2,2))]*v[$(idx(3,3))] - v[$(idx(2,3))]*v[$(idx(3,2))]) * dinv,
-                -(v[$(idx(2,1))]*v[$(idx(3,3))] - v[$(idx(2,3))]*v[$(idx(3,1))]) * dinv,
-                 (v[$(idx(2,1))]*v[$(idx(3,2))] - v[$(idx(2,2))]*v[$(idx(3,1))]) * dinv,
+@inline Base.inv(t::SymmetricTensor{2, 1}) = SymmetricTensor{2, 1}((1 / det(t),))
+@inline function Base.inv(t::SymmetricTensor{2, 2})
+    dinv = 1 / det(t)
+    @inbounds SymmetricTensor{2, 2}((t[2,2] * dinv, -t[2,1] * dinv,
+                                     t[1,1] * dinv))
+end
+@inline function Base.inv(t::SymmetricTensor{2, 3})
+    dinv = 1 / det(t)
+    @inbounds SymmetricTensor{2, 3}((
+         (t[2,2]*t[3,3] - t[2,3]*t[3,2]) * dinv,
+        -(t[2,1]*t[3,3] - t[2,3]*t[3,1]) * dinv,
+         (t[2,1]*t[3,2] - t[2,2]*t[3,1]) * dinv,
 
-                 (v[$(idx(1,1))]*v[$(idx(3,3))] - v[$(idx(1,3))]*v[$(idx(3,1))]) * dinv,
-                -(v[$(idx(1,1))]*v[$(idx(3,2))] - v[$(idx(1,2))]*v[$(idx(3,1))]) * dinv,
+         (t[1,1]*t[3,3] - t[1,3]*t[3,1]) * dinv,
+        -(t[1,1]*t[3,2] - t[1,2]*t[3,1]) * dinv,
 
-                 (v[$(idx(1,1))]*v[$(idx(2,2))] - v[$(idx(1,2))]*v[$(idx(2,1))]) * dinv))
-        end
-    end
-    return quote
-        $(Expr(:meta, :inline))
-        dinv = 1 / det(t)
-        @inbounds return $ex
-    end
+         (t[1,1]*t[2,2] - t[1,2]*t[2,1]) * dinv))
 end
 
-function Base.inv(t::Tensor{4, dim}) where {dim}
-    fromvoigt(Tensor{4, dim}, inv(tovoigt(t)))
-end
-
-function Base.inv(t::SymmetricTensor{4, dim, T}) where {dim, T}
-    frommandel(SymmetricTensor{4, dim}, inv(tomandel(t)))
-end
-
-function Base.inv(t::Tensor{4, dim, <:Real}) where {dim}
-    fromvoigt(Tensor{4, dim}, inv(tovoigt(SMatrix, t)))
-end
-
-function Base.inv(t::SymmetricTensor{4, dim, T}) where {dim, T<:Real}
-    frommandel(SymmetricTensor{4, dim}, inv(tomandel(SMatrix, t)))
-end
+# Generic fallback via Matrix; the fast SMatrix path does not support
+# non-`Real` eltypes such as unitful quantities.
+Base.inv(t::Tensor{4, dim}) where {dim} = fromvoigt(Tensor{4, dim}, inv(tovoigt(t)))
+Base.inv(t::SymmetricTensor{4, dim}) where {dim} = frommandel(SymmetricTensor{4, dim}, inv(tomandel(t)))
+Base.inv(t::Tensor{4, dim, <:Real}) where {dim} = fromvoigt(Tensor{4, dim}, inv(tovoigt(SMatrix, t)))
+Base.inv(t::SymmetricTensor{4, dim, <:Real}) where {dim} = frommandel(SymmetricTensor{4, dim}, inv(tomandel(SMatrix, t)))
 
 
 Base.:\(S1::SecondOrderTensor, S2::AbstractTensor) = inv(S1) ⋅ S2

--- a/src/promotion_conversion.jl
+++ b/src/promotion_conversion.jl
@@ -5,29 +5,23 @@
 # Promotion between two tensors promote the eltype and promotes
 # symmetric tensors to tensors
 
-@inline function Base.promote_rule(::Type{SymmetricTensor{order, dim, A, M}},
-                                   ::Type{SymmetricTensor{order, dim, B, M}}) where {dim, A, B, order, M}
-    SymmetricTensor{order, dim, promote_type(A, B), M}
+for TT in (Tensor, SymmetricTensor)
+    @eval @inline function Base.promote_rule(::Type{$TT{order, dim, A, M}},
+                                             ::Type{$TT{order, dim, B, M}}) where {order, dim, A, B, M}
+        $TT{order, dim, promote_type(A, B), M}
+    end
 end
 
-@inline function Base.promote_rule(::Type{Tensor{order, dim, A, M}},
-                                   ::Type{Tensor{order, dim, B, M}}) where {dim, A, B, order, M}
-    Tensor{order, dim, promote_type(A, B), M}
-end
-
+# one direction suffices: Base tries promote_rule with both argument orders
 @inline function Base.promote_rule(::Type{SymmetricTensor{order, dim, A, M1}},
                                    ::Type{Tensor{order, dim, B, M2}}) where {dim, A, B, order, M1, M2}
     Tensor{order, dim, promote_type(A, B), M2}
 end
 
-@inline function Base.promote_rule(::Type{Tensor{order, dim, A, M1}},
-                                   ::Type{SymmetricTensor{order, dim, B, M2}}) where {dim, A, B, order, M1, M2}
-    Tensor{order, dim, promote_type(A, B), M1}
-end
-
 # inlined promote (promote in Base is not inlined)
 @inline function Base.promote(S1::T, S2::S) where {T <: AbstractTensor, S <: AbstractTensor}
-    return convert(promote_type(T, S), S1), convert(promote_type(T, S), S2)
+    TS = promote_type(T, S)
+    return convert(TS, S1), convert(TS, S2)
 end
 # NOTE: Base's contract for one-argument `promote(x)` is to return `(x,)`;
 # it is not extended here (use `densify` to convert a symmetric tensor to a
@@ -52,26 +46,22 @@ end
 # Conversions #
 ###############
 
-# Identity conversions
-@inline Base.convert(::Type{Tensor{order, dim, T}}, t::Tensor{order, dim, T}) where {order, dim, T} = t
-@inline Base.convert(::Type{Tensor{order, dim, T, M}}, t::Tensor{order, dim, T, M}) where {order, dim, T, M} = t
-@inline Base.convert(::Type{SymmetricTensor{order, dim, T}}, t::SymmetricTensor{order, dim, T}) where {order, dim, T} = t
-@inline Base.convert(::Type{SymmetricTensor{order, dim, T, M}}, t::SymmetricTensor{order, dim, T, M}) where {order, dim, T, M} = t
-
-# Change element type
-@inline function Base.convert(::Type{Tensor{order, dim, T1}}, t::Tensor{order, dim, T2}) where {order, dim, T1, T2}
-    apply_all(Tensor{order, dim}, @inline function(i) @inbounds T1(t.data[i]); end)
+# Identity, eltype change, and peeling off M (so that convert(typeof(...), ...)
+# works) — identical for both tensor types
+for TT in (Tensor, SymmetricTensor)
+    @eval begin
+        @inline Base.convert(::Type{$TT{order, dim, T}}, t::$TT{order, dim, T}) where {order, dim, T} = t
+        @inline Base.convert(::Type{$TT{order, dim, T, M}}, t::$TT{order, dim, T, M}) where {order, dim, T, M} = t
+        @inline function Base.convert(::Type{$TT{order, dim, T1}}, t::$TT{order, dim, T2}) where {order, dim, T1, T2}
+            apply_all($TT{order, dim}, @inline function(i) @inbounds T1(t.data[i]); end)
+        end
+        @inline Base.convert(::Type{$TT{order, dim, T1, M}}, t::$TT{order, dim}) where {order, dim, T1, M} = convert($TT{order, dim, T1}, t)
+    end
 end
 
-@inline function Base.convert(::Type{SymmetricTensor{order, dim, T1}}, t::SymmetricTensor{order, dim, T2}) where {order, dim, T1, T2}
-    apply_all(SymmetricTensor{order, dim}, @inline function(i) @inbounds T1(t.data[i]); end)
-end
-
-# Peel off the M but define these so that convert(typeof(...), ...) works
-@inline Base.convert(::Type{Tensor{order, dim, T1, M}}, t::Tensor{order, dim})                   where {order, dim, T1, M} = convert(Tensor{order, dim, T1}, t)
-@inline Base.convert(::Type{SymmetricTensor{order, dim, T1, M}}, t::SymmetricTensor{order, dim}) where {order, dim, T1, M} = convert(SymmetricTensor{order, dim, T1}, t)
-@inline Base.convert(::Type{Tensor{order, dim, T1, M}}, t::SymmetricTensor{order, dim})          where {order, dim, T1, M} = convert(Tensor{order, dim, T1}, t)
-@inline Base.convert(::Type{SymmetricTensor{order, dim, T1, M}}, t::Tensor{order, dim})          where {order, dim, T1, M} = convert(SymmetricTensor{order, dim, T1}, t)
+# Tensor <-> SymmetricTensor: peel off M and fill in the eltype from the source
+@inline Base.convert(::Type{Tensor{order, dim, T1, M}}, t::SymmetricTensor{order, dim}) where {order, dim, T1, M} = convert(Tensor{order, dim, T1}, t)
+@inline Base.convert(::Type{SymmetricTensor{order, dim, T1, M}}, t::Tensor{order, dim}) where {order, dim, T1, M} = convert(SymmetricTensor{order, dim, T1}, t)
 
 @inline Base.convert(::Type{Tensor{order, dim}}, t::SymmetricTensor{order, dim, T}) where {order, dim, T} = convert(Tensor{order, dim, T}, t)
 @inline Base.convert(::Type{SymmetricTensor{order, dim}}, t::Tensor{order, dim, T}) where {order, dim, T} = convert(SymmetricTensor{order, dim, T}, t)
@@ -79,12 +69,8 @@ end
 @inline Base.convert(::Type{SymmetricTensor}, t::Tensor{order, dim, T})             where {order, dim, T} = convert(SymmetricTensor{order, dim, T}, t)
 
 # SymmetricTensor -> Tensor
-@inline function Base.convert(::Type{Tensor{2, dim, T1}}, t::SymmetricTensor{2, dim, T2}) where {dim, T1, T2}
-    Tensor{2, dim}(@inline function(i,j) @inbounds T1(t[i,j]); end)
-end
-
-@inline function Base.convert(::Type{Tensor{4, dim, T1}}, t::SymmetricTensor{4, dim, T2}) where {dim, T1, T2}
-    Tensor{4, dim}(@inline function(i,j,k,l) @inbounds T1(t[i,j,k,l]); end)
+@inline function Base.convert(::Type{Tensor{order, dim, T1}}, t::SymmetricTensor{order, dim}) where {order, dim, T1}
+    Tensor{order, dim}(@inline function(inds...) @inbounds T1(t[inds...]); end)
 end
 
 # Tensor -> SymmetricTensor

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,7 +1,3 @@
-function tensor_create_linear(T::Union{Type{Tensor{order, dim}}, Type{SymmetricTensor{order, dim}}, Type{MixedTensor{order, dim}}}, f) where {order, dim}
-    return Expr(:tuple, [f(i) for i=1:n_components(T)]...)
-end
-
 function tensor_create(::Type{Tensor{order, dim}}, f) where {order, dim}
     return tensor_create(MixedTensor{order, Tuple{ntuple(_ -> dim, order)...}}, f)
 end


### PR DESCRIPTION
Behavior-preserving refactors, independent of the engine rewrite:

- Remove all `Base.@pure` annotations (redundant on supported Julia versions).
- `inv` for second-order tensors: straightforward per-dim `@inline` methods instead of a `@generated` function (still zero-allocation).
- `apply_all` via `ntuple(f, Val(N))` instead of `@generated` unrolling.
- Constructors: order-1 `Tensor` folded into the main definition loop, non-generated `SymmetricTensor(::AbstractArray)`, `basevec` via `ntuple`.
- Promotion/conversion: collapse duplicate `promote_rule`/`convert` methods into loops; drop the redundant reversed `promote_rule` (Base tries both orders).

Part 6/8 of the split of #252 (stacked on #257).

🤖 Generated with [Claude Code](https://claude.com/claude-code)