### PR TITLE
Support gradients of symmetric tensor valued functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `gradient` now supports functions returning a `SymmetricTensor{2}` also when the
+  input is not symmetric. Since there is no tensor type with the corresponding
+  symmetry, the symmetry of the output is dropped, i.e. the gradient of a
+  `SymmetricTensor{2, dim}` valued function of a `Vec{dim}` is a `Tensor{3, dim}`
+  and of a `Tensor{2, dim}` is a `Tensor{4, dim}` ([#262], [#263]).
+
 ### Bugfixes
 - `isminorsymmetric` and `ismajorsymmetric` previously missed certain
   asymmetric components (e.g. a tensor with `A[1,2,1,2] != A[2,1,2,1]` was
@@ -77,3 +84,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#236]: https://github.com/Ferrite-FEM/Tensors.jl/issues/236
 [#238]: https://github.com/Ferrite-FEM/Tensors.jl/issues/238
 [#240]: https://github.com/Ferrite-FEM/Tensors.jl/issues/240
+[#262]: https://github.com/Ferrite-FEM/Tensors.jl/issues/262
+[#263]: https://github.com/Ferrite-FEM/Tensors.jl/issues/263

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tensors"
 uuid = "48a634ad-e948-5137-8d70-aa71f2a747f4"
-version = "1.17.1"
+version = "1.18.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/docs/src/man/automatic_differentiation.md
+++ b/docs/src/man/automatic_differentiation.md
@@ -20,6 +20,8 @@ Instead, it is simpler to use `Tensors` own AD API to do the differentiation. Th
 
 The API for AD in `Tensors` is `gradient(f, A)` and `hessian(f, A)` where `f` is a function and `A` is a first or second order tensor. For `gradient` the function can return a scalar, vector (in case the input is a vector) or a second order tensor. For `hessian` the function should return a scalar.
 
+Note that a symmetric (`SymmetricTensor{2}` valued) output is only combined with the symmetric tensor type for the gradient when the input is symmetric as well; see the note in the [`gradient`](@ref) docstring below.
+
 When evaluating the function with dual numbers, the value (value and gradient in the case of hessian) is obtained automatically, along with the gradient. To obtain the lower order results `gradient` and `hessian` accepts a third arguement, a `Symbol`. Note that the symbol is only used to dispatch to the correct function, and thus it can be any symbol. In the examples the symbol `:all` is used to obtain all the lower order derivatives and values.
 
 ```@docs

--- a/src/automatic_differentiation.jl
+++ b/src/automatic_differentiation.jl
@@ -78,6 +78,13 @@ end
 
 @inline _extract_gradient_dual(v::AbstractTensor{<:Any, <:Any, <:Dual}, u::AbstractTensor) = _extract_gradient(makemixed(v), makemixed(u))
 
+# A symmetric output combined with a non-symmetric input, e.g. a
+# `SymmetricTensor{2, dim}`-valued function of a `Vec{dim}`. The gradient is
+# symmetric in the indices stemming from the output, but there is no tensor
+# type with that symmetry (a `Tensor{3}` in the example above), so the symmetry
+# of the output is dropped and a full tensor is returned.
+@inline _extract_gradient_dual(v::SymmetricTensor{<:Any, <:Any, <:Dual}, u::Union{Tensor, MixedTensor}) = _extract_gradient_dual(densify(v), u)
+
 @generated function _extract_gradient_dual(v::MixedTensor{order1, dims1, <:Dual}, u::MixedTensor{order2, dims2}) where {order1, dims1, order2, dims2}
     expr = Expr(:tuple)
     N1 = n_components(MixedTensor{order1, dims1})
@@ -148,6 +155,19 @@ for TensorType in (Tensor, SymmetricTensor)
         end
     end
 end
+# The remaining combinations, mirroring the dispatch for the dual case above.
+# The return type must match the one obtained when the output does depend on
+# the input, hence the symmetry of a symmetric output is dropped here as well.
+@generated function _extract_gradient_nondual(v::MixedTensor{order1, dims1, T}, u::MixedTensor{order2, dims2}) where {order1, dims1, T, order2, dims2}
+    RetType = regular_if_possible(MixedTensor{order1 + order2, Tuple{size(v)..., size(u)...}, T})
+    return quote
+        $(Expr(:meta, :inline))
+        zero($RetType)
+    end
+end
+@inline _extract_gradient_nondual(v::Tensor, u::Union{Tensor, MixedTensor}) = _extract_gradient_nondual(makemixed(v), makemixed(u))
+@inline _extract_gradient_nondual(v::MixedTensor, u::Tensor) = _extract_gradient_nondual(v, makemixed(u))
+@inline _extract_gradient_nondual(v::SymmetricTensor, u::Union{Tensor, MixedTensor}) = _extract_gradient_nondual(densify(v), u)
 
 ######################
 # Gradient insertion #
@@ -370,6 +390,28 @@ julia> ∇f = gradient(norm, A)
 
 julia> ∇f, f = gradient(norm, A, :all);
 ```
+
+!!! note "Symmetric tensor valued functions"
+    The gradient of a `SymmetricTensor{2}` valued function is symmetric in the
+    two indices originating from the output. Since there is no tensor type with
+    that symmetry, e.g. for a `Vec` input the gradient is a third order tensor,
+    the symmetry is dropped and a full `Tensor` is returned. (The exception is
+    when the input is a `SymmetricTensor{2}` as well, in which case the
+    symmetric type `SymmetricTensor{4}` can represent the gradient.)
+
+    ```jldoctest
+    julia> f(x) = symmetric(x ⊗ x);
+
+    julia> gradient(f, Vec{2}((1.0, 2.0)))
+    2×2×2 Tensor{3, 2, Float64, 8}:
+    [:, :, 1] =
+     2.0  2.0
+     2.0  0.0
+
+    [:, :, 2] =
+     0.0  1.0
+     1.0  4.0
+    ```
 """
 function gradient(f::F, v::V) where {F, V <: Union{SecondOrderTensor, Vec, Number, MixedTensor}}
     v_dual = _load(v, Tag(f, V))

--- a/test/test_ad.jl
+++ b/test/test_ad.jl
@@ -204,7 +204,53 @@ S(C) = S(C, μ, Kb)
         @test gradient(y -> gradient(x -> f(y, x), s), v)::Vec{2} ≈ Vec((v[2], v[1]))
         @test gradient(y -> gradient(x -> f(x, y), v), s)::Vec{2} ≈ Vec((v[2], v[1]))
     end
-    
+
+    @testset "f: AbstractTensor -> SymmetricTensor" begin
+        # The gradient of a symmetric tensor valued function is symmetric in the
+        # indices from the output, but since there is no tensor type with that
+        # symmetry the symmetry is dropped, i.e. a full tensor is returned.
+        δ(i, j) = i == j ? 1.0 : 0.0
+        for dim in 1:3
+            x = rand(Vec{dim})
+            A = rand(Tensor{2, dim})
+            A_sym = rand(SymmetricTensor{2, dim})
+
+            # SymmetricTensor{2} valued function of a Vec -> Tensor{3}
+            f(x::Vec) = symmetric(x ⊗ x)
+            df(x::Vec{d}) where {d} = Tensor{3, d}((i, j, k) -> δ(i, k) * x[j] + δ(j, k) * x[i])
+            @test (@inferred gradient(f, x))::Tensor{3, dim, Float64} ≈ df(x)
+            ∇f, fv = @inferred gradient(f, x, :all)
+            @test ∇f::Tensor{3, dim, Float64} ≈ df(x)
+            @test fv::SymmetricTensor{2, dim, Float64} ≈ f(x)
+
+            # SymmetricTensor{2} valued function of a Tensor{2} -> Tensor{4}
+            @test (@inferred gradient(symmetric, A))::Tensor{4, dim, Float64} ⊡ A ≈ symmetric(A)
+            @test (@inferred gradient(symmetric, A, :all))[2]::SymmetricTensor{2, dim, Float64} ≈ symmetric(A)
+
+            # Symmetric input and symmetric output is unaffected, i.e. the
+            # symmetry of the resulting SymmetricTensor{4} is kept
+            @test (@inferred gradient(symmetric, A_sym))::SymmetricTensor{4, dim, Float64} ≈ one(SymmetricTensor{4, dim})
+
+            # Functions that do not return duals
+            B_sym = rand(SymmetricTensor{2, dim})
+            @test (@inferred gradient(x -> B_sym, x))::Tensor{3, dim, Float64} ≈ zero(Tensor{3, dim})
+            @test (@inferred gradient(A -> B_sym, A))::Tensor{4, dim, Float64} ≈ zero(Tensor{4, dim})
+            @test (@inferred gradient(A -> B_sym, A_sym))::SymmetricTensor{4, dim, Float64} ≈ zero(SymmetricTensor{4, dim})
+            @test (@inferred gradient(x -> B_sym, x, :all))[2]::SymmetricTensor{2, dim, Float64} ≈ B_sym
+
+            # Nested differentiation
+            @test (@inferred gradient(y -> gradient(f, y), x))::Tensor{4, dim, Float64} ≈
+                  Tensor{4, dim}((i, j, k, l) -> δ(i, l) * δ(j, k) + δ(j, l) * δ(i, k))
+        end
+        # Different dimensions for the output and the input give a MixedTensor
+        g(x::Vec{3}) = symmetric(Tensor{2, 2}((i, j) -> x[i] * x[j]))
+        x = rand(Vec{3})
+        ∇g = (@inferred gradient(g, x))::MixedTensor3{2, 2, 3, Float64}
+        @test ∇g ≈ MixedTensor3{2, 2, 3}((i, j, k) -> δ(i, k) * x[j] + δ(j, k) * x[i])
+        @test (@inferred gradient(x -> zero(SymmetricTensor{2, 2}), x))::MixedTensor3{2, 2, 3, Float64} ≈ zero(MixedTensor3{2, 2, 3})
+    end
+
+
 
     @testset "analytical gradient implementation" begin
         # Consider the function f(g(x)), we need to test the following variations to cover all cases


### PR DESCRIPTION
`gradient(f, x)` errored with a `MethodError` in `makemixed` when `f`
returned a `SymmetricTensor{2}` and the input `x` was not symmetric.

The gradient in this case is symmetric in the two indices originating
from the output, but there is no tensor type with that symmetry, so the
symmetry is dropped: the gradient of a `SymmetricTensor{2, dim}` valued
function is a `Tensor{3, dim}` for a `Vec{dim}` input and a
`Tensor{4, dim}` for a `Tensor{2, dim}` input. Symmetric input with
symmetric output is unchanged and still gives a `SymmetricTensor{4}`.

The corresponding return types for functions that don't return duals
(e.g. constant functions) are handled as well, which also fills in the
previously missing `MixedTensor` combinations.

Fixes #262.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
